### PR TITLE
fix(nvim): change feline.nvim back to archived version

### DIFF
--- a/src/settings/.config/nvim/lua/plugins.lua
+++ b/src/settings/.config/nvim/lua/plugins.lua
@@ -801,7 +801,7 @@ require("lazy").setup({
   },
 
   {
-    'freddiehaddad/feline.nvim',
+    'famiu/feline.nvim',
     version = '*',
     config = function()
       -- Feline statusline definition.


### PR DESCRIPTION
Per this [reddit](https://www.reddit.com/r/neovim/comments/1iebpi7/does_anyone_know_what_happened_to/) thread, freddiehaddad remove the fork version of feline.nvim from GitHub. Change back to famiu version temporally. I may switch to another statusline plugin in future.