### PR TITLE
feat(nvim): add win keys for prompt in sidekick plugin

### DIFF
--- a/src/settings/.config/nvim/lua/plugins.lua
+++ b/src/settings/.config/nvim/lua/plugins.lua
@@ -1518,6 +1518,11 @@ require("lazy").setup({
           backend = "tmux",
           enabled = true,
         },
+        win = {
+          keys = {
+            prompt = { "<a-p>", "prompt", mode = "t", desc = "insert prompt or context" },
+          },
+        },
       },
       copilot = {
         status = {


### PR DESCRIPTION
## Summary
Add win keys configuration for prompt in sidekick plugin to enable inserting prompt or context in terminal mode.