### PR TITLE
fix(opencode): update add-utils command for linux-x86_64

### DIFF
--- a/.opencode/command/add-utils.md
+++ b/.opencode/command/add-utils.md
@@ -2,7 +2,7 @@
 description: Automates the addition of a new utility package
 agent: build
 ---
-Search prebuilt linux-x86 version release of `$1` in GitHub. If the prebuilt binary is not available at GitHub, search web to find host site.
+Search GitHub for a prebuilt binary release of '$1' for the linux-x86_64 architecture. If a suitable binary is not found on GitHub, search the web for the official download site.
 Create a new file `packages/$1/package.yaml`. Following the package specification in `packages/README.md`:
 Add a test to `tests/Makefile`.
 


### PR DESCRIPTION
# 🤖 **OpenCode AI Summary**

**Purpose:** Fix the add-utils command to specify linux-x86_64.

**Summary:** Updated .opencode/command/add-utils.md to change "linux-x86" to "linux-x86_64".

---
*This summary was generated automatically by OpenCode.*