### PR TITLE
fix(copilot): package repo name

### DIFF
--- a/packages/copilot-cli/package.yaml
+++ b/packages/copilot-cli/package.yaml
@@ -1,7 +1,7 @@
 name: copilot-cli
 version: 0.0.369
 datasource: github-releases
-package: github/copilot
+package: github/copilot-cli
 init_cmds:
   - |
     mkdir -p $HOME/.local/share/personal-setup


### PR DESCRIPTION
# 🤖 **OpenCode AI Summary**

**Purpose:** Fix the copilot package repository name

**Summary:** Updated the package field in packages/copilot-cli/package.yaml from "github/copilot" to "github/copilot-cli".

---
*This summary was generated automatically by OpenCode.*