### PR TITLE
refactor(rustup): switch to build_cmds and enhance rustup installation

### DIFF
--- a/packages/rustup/package.yaml
+++ b/packages/rustup/package.yaml
@@ -5,17 +5,18 @@ package: rust-lang/rustup
 url: https://static.rust-lang.org/rustup/archive/{version}/x86_64-unknown-linux-gnu/rustup-init
 extract: false
 checksum_source: https://static.rust-lang.org/rustup/archive/{version}/x86_64-unknown-linux-gnu/rustup-init.sha256
-files:
-  - src: .
-    dst: .cache/personal-setup/init/rustup-init
-    chmod: "755"
-init_cmds:
+build_cmds:
   - |
-    RUSTUP_INIT_SKIP_SUDO_CHECK=yes \
-    RUSTUP_INIT_SKIP_PATH_CHECK=yes \
-    $HOME/.cache/personal-setup/init/rustup-init -y -q
-  - rustup -q toolchain install nightly
-  - rustup -q default nightly
-  - rustup -q component add rust-analyzer rustfmt clippy
-  - rustup -q completions bash > $HOME/.local/share/bash-completion/completions/rustup.bash
-  - rustup -q completions bash cargo > $HOME/.local/share/bash-completion/completions/cargo.bash
+    # Rustup configuration
+    export CARGO_HOME={out_dir}/.local/cargo
+    export RUSTUP_HOME={out_dir}/.local/rustup
+    export RUSTUP_INIT_SKIP_PATH_CHECK=yes
+    chmod 755 rustup-{version}
+    mv rustup-{version} rustup-init
+    # Install rustup stable toolchain (default)
+    ./rustup-init -y -q --no-modify-path --default-toolchain stable -c rust-analyzer,rustfmt,clippy,rust-src
+    # Install rustup nightly toolchain
+    $CARGO_HOME/bin/rustup -q toolchain install nightly -c rust-analyzer,rustfmt,clippy,rust-src
+    # Install rustup completions
+    $CARGO_HOME/bin/rustup -q completions bash > {out_dir}/.local/share/bash-completion/completions/rustup.bash
+    $CARGO_HOME/bin/rustup -q completions bash cargo > {out_dir}/.local/share/bash-completion/completions/cargo.bash


### PR DESCRIPTION
# 🤖 **OpenCode AI Summary**

**Purpose:** Refactor rustup package build process

**Summary:** Changed from init_cmds to build_cmds and updated the rustup installation to use proper environment variables, install both stable and nightly toolchains, and switch the default toolchain from nightly to stable.

---
*This summary was generated automatically by OpenCode.*