### PR TITLE
ci: add caching for personal-setup builds

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -39,6 +39,14 @@ jobs:
             just build_docker
           fi
 
+      - name: Cache personal-setup
+        uses: actions/cache@v4
+        with:
+          path: ~/.cache/personal-setup
+          key: personal-setup-${{ hashFiles('packages/**') }}
+          restore-keys: |
+            personal-setup-
+
       - name: Build
         id: run_build
         env:


### PR DESCRIPTION
# 🤖 **OpenCode AI Summary**

**Purpose:** Add caching to the CI workflow to improve build performance by caching personal-setup artifacts.

**Summary:** Added a cache step in the release.yml workflow to cache ~/.cache/personal-setup based on the hash of packages/** files.

---
*This summary was generated automatically by OpenCode.*