### PR TITLE
ci(workflows): remove restore-keys from cache action

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -59,8 +59,6 @@ jobs:
         with:
           path: ~/.cache/personal-setup
           key: personal-setup-${{ hashFiles('packages/**') }}
-          restore-keys: |
-            personal-setup-
 
       - name: Upload logs
         if: ${{ always() }}


### PR DESCRIPTION
# 🤖 **OpenCode AI Summary**

**Purpose:** Update CI workflow cache configuration to remove unnecessary restore-keys

**Summary:** Removed restore-keys from the cache action in the release workflow since saving cache does not utilize restore-keys options.

---
*This summary was generated automatically by OpenCode.*