### PR TITLE
feat(nvim): add render-markdown plugin

### DIFF
--- a/src/settings/.config/nvim/lua/plugins.lua
+++ b/src/settings/.config/nvim/lua/plugins.lua
@@ -1608,6 +1608,19 @@ require("lazy").setup({
       },
     },
   },
+
+  {
+    'MeanderingProgrammer/render-markdown.nvim',
+    dependencies = {
+      'nvim-treesitter/nvim-treesitter',
+      'nvim-tree/nvim-web-devicons'
+    },
+    ft = 'markdown',
+    cmd = { 'RenderMarkdown' },
+    ---@module 'render-markdown'
+    ---@type render.md.UserConfig
+    opts = {},
+  },
 },
 {
   defaults = {


### PR DESCRIPTION
# 🤖 **OpenCode AI Summary**

**Purpose:** Add render-markdown plugin to Neovim configuration for enhanced markdown rendering.

**Summary:** Added the render-markdown.nvim plugin to the Neovim plugins list, along with its dependencies (nvim-treesitter and nvim-web-devicons). Configured the plugin to load on markdown files and provide the RenderMarkdown command.

---
*This summary was generated automatically by OpenCode.*