### PR TITLE
fix(packages): correct man page installation paths

### DIFF
--- a/packages/bat/package.yaml
+++ b/packages/bat/package.yaml
@@ -9,6 +9,6 @@ files:
   - src: bat
     dst: .local/bin/bat
   - src: bat.1
-    dst: .local/man/man1/bat.1
+    dst: .local/share/man/man1/bat.1
   - src: autocomplete/bat.bash
     dst: .local/share/bash-completion/completions/bat.bash

--- a/packages/fd/package.yaml
+++ b/packages/fd/package.yaml
@@ -9,6 +9,6 @@ files:
   - src: fd
     dst: .local/bin/fd
   - src: fd.1
-    dst: .local/man/man1/fd.1
+    dst: .local/share/man/man1/fd.1
   - src: autocomplete/fd.bash
     dst: .local/share/bash-completion/completions/fd.bash

--- a/packages/fzf/package.yaml
+++ b/packages/fzf/package.yaml
@@ -9,7 +9,7 @@ files:
   - src: fzf
     dst: .local/bin/fzf
   - src: https://raw.githubusercontent.com/junegunn/fzf/v{version}/man/man1/fzf.1
-    dst: .local/man/man1/fzf.1
+    dst: .local/share/man/man1/fzf.1
   - src: https://raw.githubusercontent.com/junegunn/fzf/v{version}/shell/completion.bash
     dst: .local/share/scripts/fzf-completion.bash
   - src: https://raw.githubusercontent.com/junegunn/fzf/v{version}/shell/key-bindings.bash

--- a/packages/genlint/package.yaml
+++ b/packages/genlint/package.yaml
@@ -9,6 +9,6 @@ files:
   - src: genlint
     dst: .local/bin/genlint
   - src: genlint.1
-    dst: .local/man/man1/genlint.1
+    dst: .local/share/man/man1/genlint.1
   - src: genlint.bash
     dst: .local/share/bash-completion/completions/genlint.bash

--- a/packages/htop/package.yaml
+++ b/packages/htop/package.yaml
@@ -10,4 +10,4 @@ files:
     dst: .local/bin/htop
     chmod: "755"
   - src: https://github.com/henry-hsieh/htop.appimage/releases/download/v{version}/htop.1
-    dst: .local/man/man1/htop.1
+    dst: .local/share/man/man1/htop.1

--- a/packages/tmux/package.yaml
+++ b/packages/tmux/package.yaml
@@ -11,4 +11,4 @@ files:
     dst: .local/bin/tmux
     chmod: "755"
   - src: https://github.com/henry-hsieh/tmux.appimage/releases/download/v{version}/tmux.1
-    dst: .local/man/man1/tmux.1
+    dst: .local/share/man/man1/tmux.1

--- a/packages/yq/package.yaml
+++ b/packages/yq/package.yaml
@@ -9,6 +9,6 @@ files:
   - src: yq_linux_amd64
     dst: .local/bin/yq
   - src: yq.1
-    dst: .local/man/man1/yq.1
+    dst: .local/share/man/man1/yq.1
 init_cmds:
   - yq shell-completion bash > $HOME/.local/share/bash-completion/completions/yq.bash


### PR DESCRIPTION
# 🤖 **OpenCode AI Summary**

**Purpose:** Fix man page installation paths in package configurations

**Summary:** Changed destination from .local/man/man1/ to .local/share/man/man1/ for all affected packages.

---
*This summary was generated automatically by OpenCode.*