### PR TITLE
fix(nvim-lint): change stream from both to stdout in plugins.lua

### DIFF
--- a/src/settings/.config/nvim/lua/plugins.lua
+++ b/src/settings/.config/nvim/lua/plugins.lua
@@ -1354,7 +1354,7 @@ require("lazy").setup({
             end
             return base_args
           end)(),
-          stream = 'both',
+          stream = 'stdout',
           parser = function(output, bufnr)
             local decoded = vim.json.decode(output) or {}
             local result = {}


### PR DESCRIPTION
# 🤖 **OpenCode AI Summary**

**Purpose:** Fix nvim-lint plugin stream configuration to use stdout instead of both

**Summary:** Modified src/settings/.config/nvim/lua/plugins.lua to change the stream parameter from 'both' to 'stdout' for better output handling.

---
*This summary was generated automatically by OpenCode.*