### PR TITLE
fix(nvim): correct genlint diagnostic end column with safety check and source name

### DIFF
--- a/src/settings/.config/nvim/lua/plugins.lua
+++ b/src/settings/.config/nvim/lua/plugins.lua
@@ -1370,8 +1370,8 @@ require("lazy").setup({
                 lnum = diagnostic.lnum,
                 end_lnum = diagnostic.end_lnum,
                 col = diagnostic.col,
-                end_col = diagnostic.end_col,
-                source = "genlint validate",
+                end_col = diagnostic.end_col and (diagnostic.end_col + 1) or nil,
+                source = "Genlint",
                 severity = genlint_severity[diagnostic.severity],
                 filename = buf_path,
               }


### PR DESCRIPTION
# 🤖 **OpenCode AI Summary**

**Purpose:** Fix genlint diagnostic issues in Neovim configuration

**Summary:** Adjusted the diagnostic end_col by adding 1 with a safety check for diagnostic.col existence and updated the source name to "Genlint" in the plugins.lua file.

---
*This summary was generated automatically by OpenCode.*