### PR TITLE
fix(svlangserver): use manual installed version of svlangserver

### DIFF
--- a/src/settings/.config/nvim/lua/config/defaults.lua
+++ b/src/settings/.config/nvim/lua/config/defaults.lua
@@ -17,7 +17,6 @@ M.lsp = {
   -- LSP servers to install via Mason
   ensure_installed = {
     "clangd",
-    "svlangserver",
     "verible",
     "vimls",
     "pyright",

--- a/src/settings/.config/nvim/lua/plugins/lsp.lua
+++ b/src/settings/.config/nvim/lua/plugins/lsp.lua
@@ -192,6 +192,7 @@ return {
       vim.lsp.config("svlangserver", {
         filetypes = extend_filetypes("svlangserver", "verilog_systemverilog"),
       })
+      vim.lsp.enable("svlangserver")
       --- verible
       vim.lsp.config("verible", {
         cmd = { 'verible-verilog-ls', '--rules_config_search', '--push_diagnostic_notifications=false' },

--- a/tests/Makefile
+++ b/tests/Makefile
@@ -6,11 +6,11 @@ all: shellrc utils nvim-plugins mason-packages ts-parsers
 
 shellrc: bash tcsh
 
-utils: bat fd fzf git-extras lazygit genlint gh node npm opencode htop nvim rg tinty tmux bun uv rustup rust-analyzer rustfmt cargo-clippy lua-language-server tree-sitter java just wezterm yq yazi zoxide
+utils: bat fd fzf git-extras lazygit genlint gh node npm opencode htop nvim rg tinty tmux bun uv rustup rust-analyzer rustfmt cargo-clippy lua-language-server svlangserver tree-sitter java just wezterm yq yazi zoxide
 
 nvim-plugins: lazy.nvim nvim-treesitter nvim-ufo mason.nvim gitsigns.nvim blink.cmp lualine.nvim Comment.nvim which-key.nvim tabby.nvim noice.nvim lazydev.nvim flash.nvim snacks.nvim tinted-nvim trouble.nvim yazi.nvim nvim-lint sidekick.nvim riscv-asm-vim verilog_systemverilog.vim
 
-mason-packages: clangd svlangserver verible-verilog-ls vim-language-server pyright harper-ls bash-language-server typescript-language-server vscode-json-language-server copilot-language-server
+mason-packages: clangd verible-verilog-ls vim-language-server pyright harper-ls bash-language-server typescript-language-server vscode-json-language-server copilot-language-server
 
 $(LOG_DIR):
 	@mkdir -p $(LOG_DIR)
@@ -93,6 +93,9 @@ tree-sitter: | $(LOG_DIR)
 	@{ "$@" --version 2> >(tee -a $(LOG_DIR)/$@.log >&2); } > $(LOG_DIR)/$@.log
 
 lua-language-server: | $(LOG_DIR)
+	@{ "$@" --version 2> >(tee -a $(LOG_DIR)/$@.log >&2); } > $(LOG_DIR)/$@.log
+
+svlangserver: | $(LOG_DIR)
 	@{ "$@" --version 2> >(tee -a $(LOG_DIR)/$@.log >&2); } > $(LOG_DIR)/$@.log
 
 java: | $(LOG_DIR)
@@ -180,9 +183,6 @@ verilog_systemverilog.vim: | $(LOG_DIR) nvim-fresh-start
 
 # Test mason packages
 clangd: | $(LOG_DIR)
-	@{ $(HOME)/.local/share/nvim/mason/bin/"$@" --version 2> >(tee -a $(LOG_DIR)/$@.log >&2); } > $(LOG_DIR)/$@.log
-
-svlangserver: | $(LOG_DIR)
 	@{ $(HOME)/.local/share/nvim/mason/bin/"$@" --version 2> >(tee -a $(LOG_DIR)/$@.log >&2); } > $(LOG_DIR)/$@.log
 
 verible-verilog-ls: | $(LOG_DIR)


### PR DESCRIPTION
# 🤖 **OpenCode AI Summary**

**Purpose:** fix(svlangserver): use manual installed version of svlangserver

**Summary:** Updated Neovim LSP configuration to use manually installed svlangserver instead of automatic installation. Changes include modifications to defaults.lua and lsp.lua files.

---
*This summary was generated automatically by OpenCode.*