### PR TITLE
feat(opencode): add opencode-workflows templates via symlinks

### DIFF
--- a/packages/opencode-workflows/create_symlinks.py
+++ b/packages/opencode-workflows/create_symlinks.py
@@ -1,0 +1,59 @@
+import argparse
+import json
+import sys
+from pathlib import Path
+
+def main():
+    parser = argparse.ArgumentParser(
+        description="Create symlinks for opencode workflows from a manifest."
+    )
+    parser.add_argument("out_dir", type=Path, help="The output directory.")
+    parser.add_argument(
+        "manifest_path", type=Path, help="Path to the JSON manifest file."
+    )
+    args = parser.parse_args()
+
+    out_dir = args.out_dir
+    manifest_path = args.manifest_path
+
+    try:
+        with manifest_path.open() as f:
+            manifest = json.load(f)
+    except FileNotFoundError:
+        sys.exit(f"Error: Manifest file not found at {manifest_path}")
+    except json.JSONDecodeError as e:
+        sys.exit(f"Error: Invalid JSON in {manifest_path}: {e}")
+    except OSError as e:
+        sys.exit(f"Error: Could not read manifest file at {manifest_path}: {e}")
+
+    base_config_dir = out_dir / ".config" / "opencode"
+    workflows_dir_name = "opencode-workflows"
+
+    for category, items in manifest.items():
+        category_dir = base_config_dir / category
+        category_dir.mkdir(parents=True, exist_ok=True)
+
+        for name, src_rel_path in items.items():
+            if '..' in Path(src_rel_path).parts:
+                print(f"Warning: Skipping '{name}' due to potentially unsafe path '{src_rel_path}'.", file=sys.stderr)
+                continue
+
+            target_path = category_dir / name
+            # Source path relative to category_dir
+            # e.g., from .config/opencode/agents/ to .config/opencode/opencode-workflows/path/to/file
+            # is ../opencode-workflows/path/to/file
+            src_link_target = Path("..") / workflows_dir_name / src_rel_path
+
+            if target_path.is_dir() and not target_path.is_symlink():
+                print(f"Warning: Skipping {target_path} because it is a directory.", file=sys.stderr)
+                continue
+
+            if target_path.exists() or target_path.is_symlink():
+                target_path.unlink()
+
+            print(f"Creating symlink: {target_path} -> {src_link_target}")
+            target_path.symlink_to(src_link_target)
+
+
+if __name__ == "__main__":
+    main()

--- a/packages/opencode-workflows/package.yaml
+++ b/packages/opencode-workflows/package.yaml
@@ -1,0 +1,12 @@
+name: opencode-workflows
+version: "8e28cc50917708eba3d036218e332aea75067d54"
+datasource: git-refs
+branch: master
+package: IgorWarzocha/Opencode-Workflows
+url: https://github.com/IgorWarzocha/Opencode-Workflows.git
+checksum_source: git-refs
+files:
+  - src: .
+    dst: .config/opencode/opencode-workflows
+build_cmds:
+  - python3 {pkg_dir}/create_symlinks.py {out_dir} {pkg_dir}/workflows.json

--- a/packages/opencode-workflows/workflows.json
+++ b/packages/opencode-workflows/workflows.json
@@ -1,0 +1,31 @@
+{
+  "agent": {
+    "fast.md": "agents/generic/.opencode/agent/fast.md",
+    "smart.md": "agents/generic/.opencode/agent/smart.md",
+    "subagent-orchestrator.md": "agents/generic/.opencode/agent/subagent-orchestrator.md",
+    "openspec-orchestrator.md": "agents/generic/.opencode/agent/openspec-orchestrator.md",
+    "repo-navigator.md": "agents/repo-navigator/agent/repo-navigator.md",
+    "opencode-configurator.md": "agents/opencode-configurator/agent/opencode-configurator.md"
+  },
+  "command": {
+    "loop.md": "commands/.opencode/command/loop.md",
+    "refactor.md": "commands/.opencode/command/refactor.md",
+    "refactor-rfc-xml.md": "commands/.opencode/command/refactor-rfc-xml.md",
+    "improve-run.md": "commands/.opencode/command/improve-run.md",
+    "improve-save.md": "commands/.opencode/command/improve-save.md",
+    "init.md": "agents/repo-navigator/command/init.md",
+    "learn.md": "agents/repo-navigator/command/learn.md",
+    "howto.md": "commands/.opencode/command/howto.md",
+    "rmslop.md": "commands/.opencode/command/rmslop.md"
+  },
+  "skill": {
+    "agent-architect": "agents/opencode-configurator/skill/agent-architect",
+    "command-creator": "agents/opencode-configurator/skill/command-creator",
+    "skill-creator": "agents/opencode-configurator/skill/skill-creator",
+    "opencode-config": "agents/opencode-configurator/skill/opencode-config",
+    "plugin-installer": "agents/opencode-configurator/skill/plugin-installer",
+    "mcp-installer": "agents/opencode-configurator/skill/mcp-installer",
+    "agent-navigation-sop": "agents/repo-navigator/skill/agent-navigation-sop",
+    "user-onboard-sop": "agents/repo-navigator/skill/user-onboard-sop"
+  }
+}

--- a/packages/opencode/opencode.json
+++ b/packages/opencode/opencode.json
@@ -1,6 +1,11 @@
 {
   "$schema": "schema.json",
   "autoupdate": false,
+  "agent": {
+    "general": {
+      "disable": true
+    }
+  },
   "plugin": [
     "@howaboua/opencode-roadmap-plugin@0.2.1",
     "opencode-antigravity-auth@1.4.3"

--- a/src/install.sh
+++ b/src/install.sh
@@ -59,6 +59,10 @@ rm -rf $INSTALL_DIR/.local/share/nvim/runtime
 rm -rf $INSTALL_DIR/.local/lib/node_modules/npm/
 rm -rf $INSTALL_DIR/.local/lib/node_modules/corepack/
 rm -rf $INSTALL_DIR/.cache/opencode
+rm -rf $INSTALL_DIR/.config/opencode/opencode-workflows
+if [[ -d $INSTALL_DIR/.config/opencode ]]; then
+  find $INSTALL_DIR/.config/opencode -type l -lname '../opencode-workflows/*' -delete
+fi
 untar $SCRIPT_DIR/home.tar.gz
 echo -e "Clean plugins..."
 cd $INSTALL_DIR/.local/share/nvim/lazy


### PR DESCRIPTION
## Summary
- Added `packages/opencode-workflows` to integrate templates from IgorWarzocha/Opencode-Workflows.
- Uses a symlink-based approach to keep templates auto-updatable via Renovate (`git-refs`).
- Implemented `create_symlinks.py` to manage relative symlinks within the build output.
- Updated `src/install.sh` to clean up old workflows and dangling symlinks during installation.