### PR TITLE
fix(tinty): exclude symlinks and lock file from release

### DIFF
--- a/justfile
+++ b/justfile
@@ -15,7 +15,7 @@ fast_fail_cmd := if fast_fail != "0" { "--fast-fail" } else { "" }
 out := build_dir / "personal-setup.tar.gz"
 cache_include_list := "opencode"
 find_args := prepend("! -name ", cache_include_list)
-static_exclude_list := ".npm .bash_history .tcsh_history .local/state tinty/current_scheme"
+static_exclude_list := ".npm .bash_history .tcsh_history .local/state"
 tar_static_excludes := prepend("--exclude=", static_exclude_list)
 
 # Recipes
@@ -48,6 +48,7 @@ start_service:
 release: (build_home)
     mkdir -p {{build_dir}}/release
     cd {{output_dir}} && find .cache -mindepth 1 -maxdepth 1 {{find_args}} -printf "%p\n" > {{build_dir}}/exclude.list
+    cd {{output_dir}} && find .local/share/tinted-theming/tinty \( -type l -o -name ".tinty.lock" \) -printf "%p\n" >> {{build_dir}}/exclude.list
     cd {{output_dir}} && tar -czf ../release/home.tar.gz \
         {{tar_static_excludes}} \
         --exclude-from={{build_dir}}/exclude.list \


### PR DESCRIPTION
# OpenCode AI Summary

**Purpose:** Improve release packaging by excluding tinty build artifacts

**Summary:** This PR updates the justfile to dynamically exclude all symlinks in the tinty directory instead of just the `current_scheme` symlink. It also adds the `.tinty.lock` file to the static exclusion list. This ensures build artifacts are not included in the release archive.

**Changes:**
- Added dynamic exclusion for all symlinks in `.local/share/tinted-theming/tinty/` using `find -type l`
- Removed redundant `tinty/current_scheme` from static exclude list
- Added `.local/share/tinted-theming/tinty/.tinty.lock` to static exclude list

---
*This summary was generated automatically by OpenCode.*