### PR TITLE
feat(direnv): add direnv package

### DIFF
--- a/packages/direnv/package.yaml
+++ b/packages/direnv/package.yaml
@@ -1,0 +1,21 @@
+name: direnv
+version: 2.37.1
+datasource: github-releases
+package: direnv/direnv
+url: https://github.com/direnv/direnv/releases/download/v{version}/direnv.linux-amd64
+extract: false
+checksum_source: github-release
+files:
+  - src: .
+    dst: .local/bin/direnv
+    chmod: "755"
+  - src: https://raw.githubusercontent.com/direnv/direnv/v{version}/man/direnv.1
+    dst: .local/share/man/man1/direnv.1
+  - src: https://raw.githubusercontent.com/direnv/direnv/v{version}/man/direnv-stdlib.1
+    dst: .local/share/man/man1/direnv-stdlib.1
+  - src: https://raw.githubusercontent.com/direnv/direnv/v{version}/man/direnv-fetchurl.1
+    dst: .local/share/man/man1/direnv-fetchurl.1
+  - src: https://raw.githubusercontent.com/direnv/direnv/v{version}/man/direnv.toml.1
+    dst: .local/share/man/man1/direnv.toml.1
+test:
+  type: version-check

--- a/src/settings/.bashrc
+++ b/src/settings/.bashrc
@@ -265,3 +265,4 @@ if [ -f ~/.bashrc.post ]; then
 fi
 
 eval "$(zoxide init bash)"
+eval "$(direnv hook bash)"

--- a/src/settings/.config/direnv/direnvrc
+++ b/src/settings/.config/direnv/direnvrc
@@ -1,0 +1,44 @@
+# Usage: layout uv [strategy]
+#
+# Enables the uv project layout in the current directory, and syncs
+# the dependencies in the project based on strategy argument.
+#
+# Strategies:
+#   - update: Always update to the newest dependencies
+#   - frozen: (Default) Sync dependencies to uv.lock
+#   - no: Don't sync (fastest)
+# This relies on the `uv` command being available in the PATH and uv's
+# configuration file and environment variables, rather than arguments.
+#
+layout_uv() {
+  local strategy=${1:-frozen}
+  local venv_path="$(expand_path "${UV_PROJECT_ENVIRONMENT:-.venv}")"
+
+  # Watch the uv configuration file for changes
+  watch_file .python-version pyproject.toml uv.lock
+
+  if [[ ! -f "pyproject.toml" ]]; then
+    log_status "No uv project exists. Executing \`uv init --bare\` to create one."
+    uv init --bare
+  fi
+  if [[ ! -d "$venv_path" ]]; then
+    log_status "No \"$venv_path\" exists. Executing \`uv venv -c\` to create one."
+    uv venv -c "$venv_path"
+  fi
+
+  case "$strategy" in
+    "update")
+      uv sync || true
+      ;;
+    "frozen")
+      uv sync --frozen || true
+      ;;
+    esac
+
+  # activate the virtualenv after syncing; this puts the newly-installed
+  # binaries on PATH.
+  if [[ -e "$venv_path" ]]; then
+    # shellcheck source=/dev/null
+    source "$venv_path/bin/activate"
+  fi
+}

--- a/src/settings/.cshrc
+++ b/src/settings/.cshrc
@@ -108,4 +108,4 @@ if ( -f ~/.cshrc.post ) then
 endif
 
 # Set precmd
-alias precmd 'history -S; history -c; history -M; source ~/.local/share/scripts/git-prompt.csh; __zoxide_hook'
+alias precmd 'history -S; history -c; history -M; source ~/.local/share/scripts/git-prompt.csh; __zoxide_hook; eval `direnv export tcsh`'


### PR DESCRIPTION
# OpenCode AI Summary

**Purpose:** Add direnv package for environment variable management

**Summary:** This PR adds a new package `direnv` (v2.37.1) to the personal-setup build system. The package downloads the official linux-amd64 binary from GitHub releases and installs it to `~/.local/bin/direnv`. Includes version-check test for verification.

---
*This summary was generated automatically by OpenCode.*