### PR TITLE
feat(opencode): add memory plugin

### DIFF
--- a/justfile
+++ b/justfile
@@ -15,7 +15,7 @@ fast_fail_cmd := if fast_fail != "0" { "--fast-fail" } else { "" }
 out := build_dir / "personal-setup.tar.gz"
 cache_include_list := "opencode"
 find_args := prepend("! -name ", cache_include_list)
-static_exclude_list := ".npm .bash_history .tcsh_history .local/state"
+static_exclude_list := ".npm .bash_history .tcsh_history .local/state .opencode-mem"
 tar_static_excludes := prepend("--exclude=", static_exclude_list)
 
 # Recipes

--- a/packages/opencode/opencode.json
+++ b/packages/opencode/opencode.json
@@ -8,7 +8,8 @@
   },
   "plugin": [
     "opencode-antigravity-auth@1.6.0",
-    "@tarquinen/opencode-dcp@3.0.4"
+    "@tarquinen/opencode-dcp@3.0.4",
+    "opencode-mem@2.12.0"
   ],
   "provider": {
     "google": {


### PR DESCRIPTION
# OpenCode AI Summary

**Purpose:** Add memory plugin to OpenCode for persistent knowledge storage across sessions.

**Summary:** Adds memory plugin configuration to OpenCode, enabling the agent to store and retrieve project-specific knowledge using the memory tool.

---
*This summary was generated automatically by OpenCode.*