### PR TITLE
fix(nvim): tinted-nvim colors

### DIFF
--- a/src/settings/.config/nvim/lua/plugins/colorscheme.lua
+++ b/src/settings/.config/nvim/lua/plugins/colorscheme.lua
@@ -6,36 +6,29 @@ return {
     init = function()
       vim.o.termguicolors = true
     end,
-    config = function()
-      -- require manual setup because the module name is not conventional
-      local tinted = require('tinted-nvim')
-      tinted.setup(nil, {
-        supports = {
-          tinted_shell = true,
-          live_reload = true,
-        },
-      })
-      vim.api.nvim_create_autocmd("User", {
-        pattern = "TintedColorsPost",
-        callback = function()
-          -- Do things whenever the theme changes.
-          local colors = require("tinted-nvim").colors
-          if colors then
-            vim.api.nvim_set_hl(0, "FlashLabel",     { fg = colors.base06, bg = colors.base08, bold = false, italic = false })
-            vim.api.nvim_set_hl(0, "FlashMatch",     { fg = colors.base06, bg = colors.base0D, bold = false, italic = false })
-            vim.api.nvim_set_hl(0, "Folded",
-              { fg = nil, bg = colors.base01, bold = false, italic = false })
-            vim.api.nvim_set_hl(0, "FoldColumn",
-              { fg = colors.base03, bg = nil, bold = false, italic = false })
-            vim.api.nvim_set_hl(0, "SnacksIndent",
-              { fg = colors.base02, bg = nil, bold = false, italic = false })
-            vim.api.nvim_set_hl(0, "SnacksIndentScope",
-              { fg = colors.base0C, bg = nil, bold = false, italic = false })
-            vim.api.nvim_set_hl(0, "StatusLine", { link = "lualine_c_normal" })
-          end
+    opts = {
+      compile = true,
+      capabilities = {
+        undercurl = true,
+      },
+      highlights = {
+        overrides = function(colors)
+          return {
+            FlashLabel        = { fg = colors.base01, bg = colors.base08, bold = false, italic = false },
+            FlashMatch        = { fg = colors.base01, bg = colors.base09, bold = false, italic = false },
+            FlashCurrent      = { fg = colors.base01, bg = colors.base0D, bold = false, italic = false },
+            Folded            = { fg = nil, bg = colors.base01, bold = false, italic = false },
+            FoldColumn        = { fg = colors.base03, bg = nil, bold = false, italic = false },
+            NonText           = { fg = colors.base03, bg = nil, bold = false, italic = false },
+            SnacksIndent      = { fg = colors.base02, bg = nil, bold = false, italic = false },
+            SnacksIndentScope = { fg = colors.base0C, bg = nil, bold = false, italic = false },
+            StatusLine        = { link = "lualine_c_normal" },
+          }
         end,
-      })
-      vim.cmd.doautocmd("User TintedColorsPost")
-    end,
+      },
+      selector = {
+        enabled = true,
+      },
+    },
   },
 }

--- a/src/settings/.config/nvim/lua/plugins/lang.lua
+++ b/src/settings/.config/nvim/lua/plugins/lang.lua
@@ -47,7 +47,7 @@ return {
     cmd = "CodeDiff",
     version = "*",
     opts = function()
-      local colors = require("tinted-colorscheme").colors
+      local colors = require("tinted-nvim").get_palette()
       local utils = require("utils")
       return {
         highlights = {

--- a/src/settings/.config/nvim/lua/plugins/ui.lua
+++ b/src/settings/.config/nvim/lua/plugins/ui.lua
@@ -49,7 +49,6 @@ return {
         return ""
       end
 
-      local theme = require('lualine.themes.tinted')
       local function winbar_sep_color(active)
         -- Terminal background
         local normal_hl = vim.api.nvim_get_hl(0, { name = 'Normal', link = false })
@@ -57,7 +56,10 @@ return {
             normal_hl.ctermbg and normal_hl.ctermbg or nil
 
         -- fg = theme bg, bg = terminal bg
-        local theme_bg = active and theme.normal.b.bg or theme.inactive.b.bg
+        local lualine_normal_b_hl = vim.api.nvim_get_hl(0, { name = 'LualineNormalB', link = false })
+        local lualine_inactive_b_hl = vim.api.nvim_get_hl(0, { name = 'LualineInactiveB', link = false })
+        local bg_val = active and lualine_normal_b_hl.bg or lualine_inactive_b_hl.bg
+        local theme_bg = bg_val and string.format("#%06x", bg_val)
 
         return {
           fg = theme_bg,
@@ -208,7 +210,7 @@ return {
       }
 
       return opts
-    end
+    end,
   },
 
   {


### PR DESCRIPTION
# OpenCode AI Summary

**Purpose:** Update tinted-nvim configuration and fix module references

**Summary:** Refactors tinted-nvim plugin configuration from manual setup to use opts, updates module reference from tinted-colorscheme to tinted-nvim in lang.lua, and fixes lualine theme color retrieval in ui.lua.

---
*This summary was generated automatically by OpenCode.*