### PR TITLE
fix(nvim): diff color

### DIFF
--- a/src/settings/.config/nvim/lua/plugins/colorscheme.lua
+++ b/src/settings/.config/nvim/lua/plugins/colorscheme.lua
@@ -23,6 +23,13 @@ return {
             SnacksIndent      = { fg = colors.base02, bg = nil, bold = false, italic = false },
             SnacksIndentScope = { fg = colors.base0C, bg = nil, bold = false, italic = false },
             StatusLine        = { link = "lualine_c_normal" },
+            DiffAdd           = { fg = "green" },
+            DiffChange        = { fg = "orange" },
+            DiffDelete        = { fg = "red" },
+            DiffText          = { fg = "blue" },
+            GitSignsAdd       = { link = "DiffAdd" },
+            GitSignsChange    = { link = "DiffChange" },
+            GitSignsDelete    = { link = "DiffDelete" },
           }
         end,
       },


### PR DESCRIPTION
# OpenCode AI Summary

**Purpose:** Add diff color highlighting for Neovim to improve visual differentiation of changes in diffs and git signs.

**Summary:** Added custom highlight groups for DiffAdd (green), DiffChange (orange), DiffDelete (red), and DiffText (blue), with GitSigns links for consistent coloring.

---
*This summary was generated automatically by OpenCode.*