### PR TITLE
feat(opencode): add custom LSPs

### DIFF
--- a/packages/opencode/opencode.json
+++ b/packages/opencode/opencode.json
@@ -11,6 +11,23 @@
     "@tarquinen/opencode-dcp@3.1.8",
     "opencode-mem@2.13.0"
   ],
+  "lsp": {
+    "slang-server": {
+      "command": ["slang-server"],
+      "extensions": [".v", ".sv", ".vh", ".svh", ".sva"]
+    },
+    "pyright": {
+      "disabled": true
+    },
+    "ruff": {
+      "command": ["ruff", "server"],
+      "extensions": [".py", ".pyi"]
+    },
+    "ty": {
+      "command": ["ty", "server"],
+      "extensions": [".py", ".pyi"]
+    }
+  },
   "provider": {
     "google": {
       "models": {


### PR DESCRIPTION
# OpenCode AI Summary

**Purpose:** Add custom language server configurations for OpenCode, including slang-server for Verilog/SystemVerilog and configuring ruff/ty for Python while disabling pyright.

**Summary:** Added LSP configuration in opencode.json with slang-server support for .v, .sv, .vh, .svh, .sva files, disabled pyright, and enabled ruff and ty language servers for Python files.

---
*This summary was generated automatically by OpenCode.*