### PR TITLE
feat(nvim): add haunt.nvim for code annotation

### DIFF
--- a/src/settings/.config/nvim/lua/plugins/editor.lua
+++ b/src/settings/.config/nvim/lua/plugins/editor.lua
@@ -49,4 +49,40 @@ return {
       return keys
     end,
   },
+  {
+    "TheNoeTrevino/haunt.nvim",
+    ---@class HauntConfig
+    opts = {
+      sign = "󱙝",
+      sign_hl = "DiagnosticInfo",
+      virt_text_hl = "HauntAnnotation",
+      annotation_prefix = " 󰆉 ",
+      line_hl = nil,
+      virt_text_pos = "eol",
+      data_dir = nil,
+      picker_keys = {
+        delete = { key = "d", mode = { "n" } },
+        edit_annotation = { key = "a", mode = { "n" } },
+      },
+    },
+    keys = {
+      -- annotations
+      { "<space>ha", function() require("haunt.api").annotate() end,                                desc = "Annotate" },
+      { "<space>ht", function() require("haunt.api").toggle_annotation() end,                       desc = "Toggle annotation" },
+      { "<space>hT", function() require("haunt.api").toggle_all_lines() end,                        desc = "Toggle all annotations" },
+      { "<space>hd", function() require("haunt.api").delete() end,                                  desc = "Delete annotation" },
+      { "<space>hD", function() require("haunt.api").clear_all() end,                               desc = "Delete all annotations" },
+      -- move
+      { "[a",        function() require("haunt.api").prev() end,                                    desc = "Previous annotation" },
+      { "]a",        function() require("haunt.api").next() end,                                    desc = "Next annotation" },
+      -- picker
+      { "<space>hl", function() require("haunt.picker").show() end,                                 desc = "Show pickers" },
+      -- quickfix
+      { "<space>hq", function() require("haunt.api").to_quickfix() end,                             desc = "Show quickfix" },
+      { "<space>hQ", function() require("haunt.api").to_quickfix({ current_buffer = true }) end,    desc = "Show quickfix of current buffer" },
+      -- yank
+      { "<space>hy", function() require("haunt.api").yank_locations() end,                          desc = "Yank locations" },
+      { "<space>hY", function() require("haunt.api").yank_locations({ current_buffer = true }) end, desc = "Yank locations of current buffer" },
+    }
+  },
 }

--- a/src/settings/.config/nvim/lua/plugins/ui.lua
+++ b/src/settings/.config/nvim/lua/plugins/ui.lua
@@ -403,6 +403,7 @@ return {
         { "<leader>x",    group = "Trouble", icon = "🚦" },
         { "<leader>y",    group = "Yazi", icon = { icon = "󰇥", color = "yellow" } },
         { "<space>b",     group = "Buffer" },
+        { "<space>h",     group = "Haunt" },
         { "<space><Tab>", group = "Tab" },
       },
     },


### PR DESCRIPTION
# OpenCode AI Summary

**Purpose:** Add haunt.nvim plugin for code annotation functionality, allowing users to annotate code and navigate between annotations.

**Summary:** Added haunt.nvim plugin with keybindings for creating, toggling, deleting, and navigating annotations. Also added a new group for Haunt in the WhichKey menu.

---
*This summary was generated automatically by OpenCode.*