### PR TITLE
fix(nvim): migrate LSP log level API to vim.lsp.log.set_level

### DIFF
--- a/src/settings/.config/nvim/lua/plugins/lsp.lua
+++ b/src/settings/.config/nvim/lua/plugins/lsp.lua
@@ -78,7 +78,7 @@ return {
       local config = require("config")
 
       -- LSP log level
-      vim.lsp.set_log_level(config.lsp.log_level)
+      vim.lsp.log.set_level(config.lsp.log_level)
 
       -- Appearance
       vim.diagnostic.config({


### PR DESCRIPTION
# OpenCode AI Summary

**Purpose:** Migrate deprecated LSP log level API to the new vim.lsp.log.set_level API for Neovim 0.12+ compatibility.

**Summary:** Changed vim.lsp.set_log_level to vim.lsp.log.set_level in the LSP configuration to use the updated API.

---
*This summary was generated automatically by OpenCode.*