### PR TITLE
build: exclude opencode user database

### DIFF
--- a/justfile
+++ b/justfile
@@ -15,7 +15,7 @@ fast_fail_cmd := if fast_fail != "0" { "--fast-fail" } else { "" }
 out := build_dir / "personal-setup.tar.gz"
 cache_include_list := "opencode"
 find_args := prepend("! -name ", cache_include_list)
-static_exclude_list := ".npm .bash_history .tcsh_history .local/state .opencode-mem"
+static_exclude_list := ".npm .bash_history .tcsh_history .local/state .local/share/opencode .opencode-mem"
 tar_static_excludes := prepend("--exclude=", static_exclude_list)
 
 # Recipes


### PR DESCRIPTION
# OpenCode AI Summary

**Purpose:** Exclude the opencode user database from the release tarball to avoid including user-specific data in the build output.

**Summary:** Added `.local/share/opencode` to the static exclude list in justfile to prevent the opencode user database from being included in the release archive.

---
*This summary was generated automatically by OpenCode.*