### PR TITLE
ci: add free disk space step before build

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -23,6 +23,19 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v6
 
+      - name: Free Disk Space
+        uses: endersonmenezes/free-disk-space@v3
+        with:
+          remove_android: true
+          remove_dotnet: true
+          remove_haskell: true
+          remove_tool_cache: true
+          remove_swap: true
+          remove_packages: "azure-cli google-cloud-cli microsoft-edge-stable google-chrome-stable firefox postgresql* temurin-* *llvm* mysql* dotnet-sdk-*"
+          remove_packages_one_command: true
+          remove_folders: "/usr/share/swift /usr/share/miniconda /usr/share/az* /usr/share/glade* /usr/local/lib/node_modules /usr/local/share/chromium /usr/local/share/powershell"
+          testing: false
+
       - name: Commit lint
         uses: wagoid/commitlint-github-action@v6
 


### PR DESCRIPTION
# OpenCode AI Summary

**Purpose:** Free up disk space on GitHub runners before build to prevent storage issues.

**Summary:** Added endersonmenezes/free-disk-space action to the release workflow, removing unnecessary packages and tools (Android SDK, .NET, Haskell, Node modules, etc.) to optimize disk usage prior to building the environment.

---
*This summary was generated automatically by OpenCode.*