### PR TITLE
feat(nvim): add scroll animation and buffer diagnostics toggles

### DIFF
--- a/src/settings/.config/nvim/lua/plugins/ui.lua
+++ b/src/settings/.config/nvim/lua/plugins/ui.lua
@@ -242,6 +242,35 @@ return {
           end
         end,
       }):map("<leader>t<Tab>")
+      Snacks.toggle.new({
+        id = "scroll",
+        name = "Scroll Animation",
+        get = function()
+          return Snacks.scroll.enabled
+        end,
+        set = function(state)
+          if state then
+            Snacks.scroll.enable()
+          else
+            Snacks.scroll.disable()
+          end
+        end,
+      }):map("<leader>ts")
+      Snacks.toggle.new({
+        id = "buf_diagnostics",
+        name = "Buffer Diagnostics",
+        get = function()
+          return vim.diagnostic.is_enabled({bufnr = 0})
+        end,
+        set = function(state)
+          if state then
+            pcall(vim.diagnostic.enable, true,  {bufnr = 0})
+          else
+            pcall(vim.diagnostic.enable, false, {bufnr = 0})
+          end
+        end,
+      }):map("<leader>tB")
+
       ---@type snacks.Config
       return {
         -- your configuration comes here


### PR DESCRIPTION
# OpenCode AI Summary

**Purpose:** Add Neovim toggle commands for scroll animation and buffer diagnostics

**Summary:** Added two new Snacks.toggle commands to nvim config: `scroll` toggle for scroll animation (mapped to `<leader>ts`) and `buf_diagnostics` toggle for per-buffer diagnostic control (mapped to `<leader>tB`).

---
*This summary was generated automatically by OpenCode.*