### PR TITLE
fix(shell): respect XDG_CONFIG_HOME

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,25 +43,55 @@ The environment supports customization through specific configuration files.
 
 ### Shell Customization
 
-You can add custom shell commands or environment variables by creating the following files in your home directory:
+You can add custom shell commands or environment variables by creating the following files:
 
 - **Bash**:
-  - `~/.bashrc.pre`: Executed at the beginning of `.bashrc`.
-  - `~/.bashrc.post`: Executed at the end of `.bashrc`.
+  - `${XDG_CONFIG_HOME}/personal-setup/bash-custom.bash`: Executed at the end of `.bashrc` (subshell).
+  - `${XDG_CONFIG_HOME}/personal-setup/bash-custom-login.bash`: Executed at the end of `.bash_profile` (login shell).
 - **Tcsh**:
-  - `~/.cshrc.pre`: Executed at the beginning of `.cshrc`.
-  - `~/.cshrc.post`: Executed at the end of `.cshrc`.
+  - `${XDG_CONFIG_HOME}/personal-setup/csh-custom.csh`: Executed at the end of `.cshrc` (subshell).
+  - `${XDG_CONFIG_HOME}/personal-setup/csh-custom-login.csh`: Executed at the end of `.login` (login shell).
+- **Fish**: Fish natively supports customization through standard paths:
+  - `${XDG_CONFIG_HOME}/fish/conf.d/*.fish`: Auto-loaded configuration snippets.
+  - `${XDG_CONFIG_HOME}/fish/functions/*.fish`: Function definitions (loaded on demand).
 
+By default, `XDG_CONFIG_HOME` is set to `~/.config`.
+
+
+### Git Customization
+
+- `${XDG_CONFIG_HOME}/git/custom.gitconfig`: Included via `[include]` in the global git config.
+
+### Tmux Customization
+
+- `${XDG_CONFIG_HOME}/tmux/custom.conf`: Sourced at the end of `tmux.conf`.
 ### Neovim Customization
 
-User-specific Neovim configurations can be placed in `~/.config/nvim/lua/custom/`.
+User-specific Neovim configurations can be placed in `${XDG_CONFIG_HOME}/nvim/lua/custom/`.
 
-- **General Settings**: Create `~/.config/nvim/lua/custom/config.lua`. The module should return a table of options to override defaults in `~/.config/nvim/lua/config/defaults.lua`.
-- **Plugins**: Add custom plugins by creating `.lua` files in the `~/.config/nvim/lua/custom/plugins/` directory. Each file should return a `lazy.nvim` plugin specification.
+- **General Settings**: Create `${XDG_CONFIG_HOME}/nvim/lua/custom/config.lua`. The module should return a table of options to override defaults in `${XDG_CONFIG_HOME}/nvim/lua/config/defaults.lua`.
+- **Plugins**: Add custom plugins by creating `.lua` files in the `${XDG_CONFIG_HOME}/nvim/lua/custom/plugins/` directory. Each file should return a `lazy.nvim` plugin specification.
+- **Tree-sitter**: Create `${XDG_CONFIG_HOME}/nvim/lua/custom/treesitter.lua` to extend Tree-sitter configuration.
+
+#### Feature Toggles
+
+You can toggle features by overriding the `features` table in your custom config:
+
+```lua
+-- ${XDG_CONFIG_HOME}/nvim/lua/custom/config.lua
+return {
+  features = {
+    copilot = false,        -- Disable Copilot/AI suggestions
+    ai_cli = false,         -- Disable AI CLI (sidekick)
+    linting = false,        -- Disable nvim-lint
+    format_on_save = true,  -- Enable auto-format on save
+  },
+}
+```
 
 ### OpenCode Customization
 
-To configure OpenCode, create `~/.config/opencode/custom.json`. The `OPENCODE_CONFIG` environment variable is automatically set to this path if the file exists.
+To configure OpenCode, create `${XDG_CONFIG_HOME}/opencode/custom.json`. The `OPENCODE_CONFIG` environment variable is automatically set to this path if the file exists.
 
 ## Development Guide
 

--- a/src/settings/.config/git/config
+++ b/src/settings/.config/git/config
@@ -69,4 +69,4 @@
     prune = true
 [include]
     path = "~/.local/share/tinted-theming/tinty/tinted-delta-configs-file.gitconfig"
-    path = "~/.config/git/custom.gitconfig"
+    path = "custom.gitconfig"

--- a/src/settings/.config/tinted-theming/tinty/config.toml
+++ b/src/settings/.config/tinted-theming/tinty/config.toml
@@ -22,7 +22,7 @@ name = "tinted-delta"
 themes-dir = "configs"
 supported-systems = ["base16", "base24"]
 
-hooks = ["tmux source-file ~/.config/tmux/tmux.conf"]
+hooks = ["tmux source-file ${XDG_CONFIG_HOME}/tmux/tmux.conf"]
 
 [[rings]]
 name = "default"

--- a/src/settings/.config/tinted-theming/tinty/fish.toml
+++ b/src/settings/.config/tinted-theming/tinty/fish.toml
@@ -22,7 +22,7 @@ name = "tinted-delta"
 themes-dir = "configs"
 supported-systems = ["base16", "base24"]
 
-hooks = ["tmux source-file ~/.config/tmux/tmux.conf"]
+hooks = ["tmux source-file ${XDG_CONFIG_HOME}/tmux/tmux.conf"]
 
 [[rings]]
 name = "default"

--- a/src/settings/.config/tmux/tmux.conf
+++ b/src/settings/.config/tmux/tmux.conf
@@ -6,7 +6,7 @@ unbind C-b
 bind C-a send-prefix
 
 # reload config without killing server
-bind r source-file ~/.config/tmux/tmux.conf \; display-message "Config reloaded..."
+bind r source-file ${XDG_CONFIG_HOME}/tmux/tmux.conf \; display-message "Config reloaded..."
 
 # "|" splits the current window vertically, and "-" splits it horizontally
 unbind %
@@ -102,16 +102,16 @@ set -g @plugin 'tmux-plugins/tpm'
 set -g @plugin 'tmux-plugins/tmux-resurrect'
 set -g @plugin 'tmux-plugins/tmux-yank'
 set -g @plugin 'tinted-theming/tinted-tmux'
-setenv -g TMUX_PLUGIN_MANAGER_PATH "$HOME/.config/tmux/plugins/"
+setenv -g TMUX_PLUGIN_MANAGER_PATH "${XDG_CONFIG_HOME}/tmux/plugins/"
 
 # tinted-tmux
 run-shell "tmux set-option -g @tinted-color $(tinty current)"
 
 # load custom tmux settings
-source-file -q ~/.config/tmux/custom.conf
+source-file -q ${XDG_CONFIG_HOME}/tmux/custom.conf
 
 # Run tpm at bottom of the script
-run '~/.config/tmux/plugins/tpm/tpm'
+run "${XDG_CONFIG_HOME}/tmux/plugins/tpm/tpm"
 
 # Put statusline config at bottom because tinted-tmux will change color
 set -g status-position "top"


### PR DESCRIPTION
# OpenCode AI Summary

**Purpose:** Update shell and tool configurations to respect XDG_CONFIG_HOME instead of using hardcoded paths

**Summary:** Modified git config, tmux.conf, and tinted-theming configs to use ${XDG_CONFIG_HOME} variable for paths, updated README documentation to reflect new XDG-compliant paths

---
*This summary was generated automatically by OpenCode.*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Updated customization guide to use XDG_CONFIG_HOME paths
  * Added shell-specific instructions for Bash, Tcsh, and Fish
  * Expanded Neovim and Git guidance, documented Neovim modules/plugins/Tree‑sitter and a Feature Toggles example
  * Preserved automatic OPENCODE_CONFIG behavior; removed legacy pre/post hook instructions

* **Chores**
  * Standardized configs and tooling to derive overrides from XDG_CONFIG_HOME (including Git and tmux)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->