### PR TITLE
feat(typst): add typst packages

### DIFF
--- a/packages/tinymist/package.yaml
+++ b/packages/tinymist/package.yaml
@@ -1,0 +1,12 @@
+name: tinymist
+version: 0.15.2
+datasource: github-releases
+package: Myriad-Dreamin/tinymist
+url: https://github.com/Myriad-Dreamin/tinymist/releases/download/v{version}/tinymist-x86_64-unknown-linux-musl.tar.gz
+extract: true
+checksum_source: github-release
+files:
+  - src: tinymist
+    dst: .local/bin/tinymist
+test:
+  type: version-check

--- a/packages/typst/package.yaml
+++ b/packages/typst/package.yaml
@@ -1,0 +1,12 @@
+name: typst
+version: 0.15.1
+datasource: github-releases
+package: typst/typst
+url: https://github.com/typst/typst/releases/download/v{version}/typst-x86_64-unknown-linux-musl.tar.xz
+extract: true
+checksum_source: github-release
+files:
+  - src: typst
+    dst: .local/bin/typst
+test:
+  type: version-check

--- a/packages/websocat/package.yaml
+++ b/packages/websocat/package.yaml
@@ -1,0 +1,13 @@
+name: websocat
+version: 1.14.1
+datasource: github-releases
+package: vi/websocat
+url: https://github.com/vi/websocat/releases/download/v{version}/websocat.x86_64-unknown-linux-musl
+extract: false
+checksum_source: github-release
+files:
+  - src: .
+    dst: .local/bin/websocat
+    chmod: "755"
+test:
+  type: version-check

--- a/src/settings/.config/nvim/lua/config/defaults.lua
+++ b/src/settings/.config/nvim/lua/config/defaults.lua
@@ -36,6 +36,7 @@ M.lsp = {
     "bashls",
     "jsonls",
     "copilot",
+    "tinymist",
   },
 
   -- Harper-ls config

--- a/src/settings/.config/nvim/lua/plugins/lang.lua
+++ b/src/settings/.config/nvim/lua/plugins/lang.lua
@@ -36,4 +36,19 @@ return {
     ---@type render.md.UserConfig
     opts = {},
   },
+
+  {
+    'chomosuke/typst-preview.nvim',
+    ft = 'typst',
+    version = '1.*',
+    opts = {
+      dependencies_bin = {
+        tinymist = 'tinymist',
+        websocat = 'websocat',
+      },
+    },
+    keys = {
+      { "<space>p", "<cmd>TypstPreviewToggle<CR>", desc = "Typst Preview Toggle" },
+    },
+  },
 }


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added new Tinymist and Typst tool packages for Linux x86_64 installs.
  - Added Websocat package pinned to version 1.14.1.
  - Enabled the Tinymist language server in the Neovim setup.
  - Added Typst preview support in Neovim, toggleable with **<space>p**, using Tinymist and Websocat.
  - Included automated version/installation verification for the installed tools.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->