### PR TITLE
feat(opencode): introduce magic-context and aft, and drop opencode-dcp

### DIFF
--- a/.cortexkit/.gitignore
+++ b/.cortexkit/.gitignore
@@ -1,0 +1,3 @@
+# >>> cortexkit:magic-context
+magic-context/
+# <<< cortexkit:magic-context

--- a/packages/opencode/opencode.jsonc
+++ b/packages/opencode/opencode.jsonc
@@ -6,9 +6,20 @@
       "disable": true
     }
   },
+  "compaction": {
+    "auto": false,
+    "prune": false
+  },
   "plugin": [
-    "opencode-antigravity-auth@1.6.0",
-    "@tarquinen/opencode-dcp@3.1.14"
+    "@cortexkit/opencode-magic-context@0.36.1",
+    "@cortexkit/aft-opencode@0.50.1",
+    [
+      "./plugins/opencode-pca.ts",
+      {
+        "strategy": "merge",
+        "enabled": true
+      }
+    ]
   ],
   "lsp": {
     "slang-server": {
@@ -25,85 +36,6 @@
     "ty": {
       "command": ["ty", "server"],
       "extensions": [".py", ".pyi"]
-    }
-  },
-  "provider": {
-    "google": {
-      "models": {
-        "antigravity-gemini-3-pro": {
-          "name": "Gemini 3 Pro (Antigravity)",
-          "limit": { "context": 1048576, "output": 65535 },
-          "modalities": { "input": ["text", "image", "pdf"], "output": ["text"] },
-          "variants": {
-            "low": { "thinkingLevel": "low" },
-            "high": { "thinkingLevel": "high" }
-          }
-        },
-        "antigravity-gemini-3.1-pro": {
-          "name": "Gemini 3.1 Pro (Antigravity)",
-          "limit": { "context": 1048576, "output": 65535 },
-          "modalities": { "input": ["text", "image", "pdf"], "output": ["text"] },
-          "variants": {
-            "low": { "thinkingLevel": "low" },
-            "high": { "thinkingLevel": "high" }
-          }
-        },
-        "antigravity-gemini-3-flash": {
-          "name": "Gemini 3 Flash (Antigravity)",
-          "limit": { "context": 1048576, "output": 65536 },
-          "modalities": { "input": ["text", "image", "pdf"], "output": ["text"] },
-          "variants": {
-            "minimal": { "thinkingLevel": "minimal" },
-            "low": { "thinkingLevel": "low" },
-            "medium": { "thinkingLevel": "medium" },
-            "high": { "thinkingLevel": "high" }
-          }
-        },
-        "antigravity-claude-sonnet-4-6": {
-          "name": "Claude Sonnet 4.6 (Antigravity)",
-          "limit": { "context": 200000, "output": 64000 },
-          "modalities": { "input": ["text", "image", "pdf"], "output": ["text"] }
-        },
-        "antigravity-claude-opus-4-6-thinking": {
-          "name": "Claude Opus 4.6 Thinking (Antigravity)",
-          "limit": { "context": 200000, "output": 64000 },
-          "modalities": { "input": ["text", "image", "pdf"], "output": ["text"] },
-          "variants": {
-            "low": { "thinkingConfig": { "thinkingBudget": 8192 } },
-            "max": { "thinkingConfig": { "thinkingBudget": 32768 } }
-          }
-        },
-        "gemini-2.5-flash": {
-          "name": "Gemini 2.5 Flash (Gemini CLI)",
-          "limit": { "context": 1048576, "output": 65536 },
-          "modalities": { "input": ["text", "image", "pdf"], "output": ["text"] }
-        },
-        "gemini-2.5-pro": {
-          "name": "Gemini 2.5 Pro (Gemini CLI)",
-          "limit": { "context": 1048576, "output": 65536 },
-          "modalities": { "input": ["text", "image", "pdf"], "output": ["text"] }
-        },
-        "gemini-3-flash-preview": {
-          "name": "Gemini 3 Flash Preview (Gemini CLI)",
-          "limit": { "context": 1048576, "output": 65536 },
-          "modalities": { "input": ["text", "image", "pdf"], "output": ["text"] }
-        },
-        "gemini-3-pro-preview": {
-          "name": "Gemini 3 Pro Preview (Gemini CLI)",
-          "limit": { "context": 1048576, "output": 65535 },
-          "modalities": { "input": ["text", "image", "pdf"], "output": ["text"] }
-        },
-        "gemini-3.1-pro-preview": {
-          "name": "Gemini 3.1 Pro Preview (Gemini CLI)",
-          "limit": { "context": 1048576, "output": 65535 },
-          "modalities": { "input": ["text", "image", "pdf"], "output": ["text"] }
-        },
-        "gemini-3.1-pro-preview-customtools": {
-          "name": "Gemini 3.1 Pro Preview Custom Tools (Gemini CLI)",
-          "limit": { "context": 1048576, "output": 65535 },
-          "modalities": { "input": ["text", "image", "pdf"], "output": ["text"] }
-        }
-      }
     }
   }
 }

--- a/packages/opencode/package.yaml
+++ b/packages/opencode/package.yaml
@@ -30,10 +30,44 @@ init_cmds:
     OPENCODE_PLUGIN_DIR=$HOME/.cache/opencode/packages/
     rm -rf $HOME/.cache/opencode/
     mkdir -p $OPENCODE_PLUGIN_DIR
-    for plugin in $(cpp -P $HOME/.config/opencode/opencode.jsonc | yq -r '.plugin[]'); do
+    for plugin in $(cpp -P $HOME/.config/opencode/opencode.jsonc | yq -r '.plugin[] | select(type == "!!str")'); do
       PLUGIN_PATH=${OPENCODE_PLUGIN_DIR}/${plugin}
       mkdir -p ${PLUGIN_PATH}
       cd ${PLUGIN_PATH}
       bun add --exact ${plugin}
       npm install --package-lock-only
+      # Pre-download Magic Context's local embedding model into the release
+      # archive so the airgap environment serves it from cache on first use.
+      if [[ "${plugin}" == @cortexkit/opencode-magic-context@* ]]; then
+        MODEL_CACHE_DIR=$HOME/.local/share/cortexkit/magic-context/models
+        MODEL_DIR="${MODEL_CACHE_DIR}/Xenova/all-MiniLM-L6-v2"
+        # Verify every artifact a partial download could leave missing, so a
+        # broken cache is healed instead of silently shipped to the airgap.
+        if [[ ! -f "${MODEL_DIR}/config.json" || ! -f "${MODEL_DIR}/tokenizer.json" \
+          || ! -f "${MODEL_DIR}/tokenizer_config.json" || ! -f "${MODEL_DIR}/onnx/model.onnx" ]]; then
+          PRECACHE_SCRIPT='import { env, pipeline } from "@huggingface/transformers";
+          env.cacheDir = process.env.MODEL_CACHE_DIR;
+          const pipe = await pipeline("feature-extraction", "Xenova/all-MiniLM-L6-v2", { dtype: "fp32" });
+          pipe.dispose?.();
+          console.log("[opencode] magic-context embedding model pre-downloaded");'
+          MODEL_CACHE_DIR="${MODEL_CACHE_DIR}" bun -e "$PRECACHE_SCRIPT"
+        fi
+      fi
+      # Pre-download AFT's embedding model + ONNX Runtime into the release
+      # archive so the airgap environment serves them from cache on first use.
+      if [[ "${plugin}" == @cortexkit/aft-opencode@* ]]; then
+        # \b keeps this from matching INVALID_ORT_VERSION in the same file
+        ORT_VERSION=$(grep -oP '\bORT_VERSION\s*=\s*"\K[^"]+' \
+          "${PLUGIN_PATH}/node_modules/@cortexkit/aft-bridge/dist/onnx-runtime.js" 2>/dev/null)
+        if [[ -n "${ORT_VERSION}" ]]; then
+          AFT_MODEL_REF="$HOME/.local/share/cortexkit/aft/semantic/models/models--Qdrant--all-MiniLM-L6-v2-onnx/refs/main"
+          AFT_MARKER="$HOME/.local/share/cortexkit/aft/onnxruntime/${ORT_VERSION}/.aft-onnx-installed"
+          if [[ ! -f "$AFT_MODEL_REF" || ! -f "$AFT_MARKER" ]]; then
+            python3 {pkg_dir}/precache-aft.py "${ORT_VERSION}"
+            echo "[opencode] AFT embedding model + ONNX Runtime ${ORT_VERSION} pre-downloaded"
+          fi
+        else
+          echo "[opencode] WARNING: could not determine AFT ONNX Runtime version; airgap pre-download skipped"
+        fi
+      fi
     done

--- a/packages/opencode/precache-aft.py
+++ b/packages/opencode/precache-aft.py
@@ -87,7 +87,15 @@ def main():
 
     ort_dir = os.path.join(storage, "onnxruntime", ORT_VERSION)
     lib_path = os.path.join(ort_dir, "libonnxruntime.so.%s" % ORT_VERSION)
-    if not os.path.exists(lib_path):
+    prov_path = os.path.join(ort_dir, "libonnxruntime_providers_shared.so")
+    so1_link = os.path.join(ort_dir, "libonnxruntime.so.1")
+    so_link = os.path.join(ort_dir, "libonnxruntime.so")
+    marker_path = os.path.join(ort_dir, ".aft-onnx-installed")
+    required = [lib_path, prov_path, so1_link, so_link, marker_path]
+    if not all(os.path.lexists(p) for p in required):
+        for stale in [lib_path, prov_path, so1_link, so_link, marker_path]:
+            if os.path.lexists(stale):
+                os.remove(stale)
         os.makedirs(ort_dir, exist_ok=True)
         tgz = fetch(
             "https://github.com/microsoft/onnxruntime/releases/download/v%s/"
@@ -110,15 +118,11 @@ def main():
         with open(lib_path, "wb") as fh:
             fh.write(lib_data)
         os.chmod(lib_path, 0o644)
-        prov_path = os.path.join(ort_dir, "libonnxruntime_providers_shared.so")
         with open(prov_path, "wb") as fh:
             fh.write(prov_data)
         os.chmod(prov_path, 0o644)
-        os.symlink(
-            "libonnxruntime.so.%s" % ORT_VERSION,
-            os.path.join(ort_dir, "libonnxruntime.so.1"),
-        )
-        os.symlink("libonnxruntime.so.1", os.path.join(ort_dir, "libonnxruntime.so"))
+        os.symlink("libonnxruntime.so.%s" % ORT_VERSION, so1_link)
+        os.symlink("libonnxruntime.so.1", so_link)
         now = datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%M:%S.") + (
             "%03dZ" % (datetime.now(timezone.utc).microsecond // 1000)
         )
@@ -128,7 +132,7 @@ def main():
             "sha256": hashlib.sha256(lib_data).hexdigest(),
             "archiveSha256": archive_sha256,
         }
-        with open(os.path.join(ort_dir, ".aft-onnx-installed"), "w") as fh:
+        with open(marker_path, "w") as fh:
             json.dump(marker, fh)
 
 

--- a/packages/opencode/precache-aft.py
+++ b/packages/opencode/precache-aft.py
@@ -1,0 +1,136 @@
+#!/usr/bin/env python3
+"""Pre-download AFT's embedding model and ONNX Runtime for offline (airgap) use.
+
+Mirrors exactly what the AFT daemon would fetch on first semantic-search use:
+
+* Embedding model Qdrant/all-MiniLM-L6-v2-onnx into the HF-hub-style layout
+  <storage>/semantic/models/models--<namespace>--<name>/ (refs/ snapshots/
+  blobs/), with LFS files named by their sha256 oid and regular files by
+  git blob sha1.
+* ONNX Runtime (version determined at build time from AFT source) shared
+  libraries plus the .aft-onnx-installed marker into
+  <storage>/onnxruntime/<version>/.
+
+<storage> is $HOME/.local/share/cortexkit/aft — the AFT daemon's default
+storage root on Linux. Both trees ship in the release archive so the airgap
+machine never hits the network.
+"""
+
+import hashlib
+import io
+import json
+import os
+import sys
+import tarfile
+import urllib.request
+from datetime import datetime, timezone
+
+if len(sys.argv) < 2:
+    raise SystemExit("Usage: precache-aft.py <ort-version>")
+ORT_VERSION = sys.argv[1]
+REPO = "Qdrant/all-MiniLM-L6-v2-onnx"
+# hf-hub Rust crate (what fastembed/AFT uses) names cache dirs
+# models--<namespace>--<name>, replacing the slash with a double dash.
+HUB_REPO = REPO.replace("/", "--")
+FILES = ["model.onnx", "tokenizer.json"]
+HF = "https://huggingface.co"
+
+
+def fetch(url):
+    # Fixed HTTPS paths only (HF_REPO/REPO, release tarballs) — no untrusted input.
+    req = urllib.request.Request(url, headers={"User-Agent": "personal-setup-build"})  # noqa: S310
+    return urllib.request.urlopen(req, timeout=300).read()  # noqa: S310
+
+
+def git_blob_sha(data):
+    # HF hub blob IDs are git-blob SHA-1 by design (not used for security).
+    return hashlib.sha1(b"blob %d\0" % len(data) + data).hexdigest()  # noqa: S324
+
+
+def main():
+    storage = os.path.expanduser("~/.local/share/cortexkit/aft")
+
+    api = json.loads(fetch("%s/api/models/%s" % (HF, REPO)).decode())
+    rev = api["sha"]
+    tree = json.loads(fetch("%s/api/models/%s/tree/main" % (HF, REPO)).decode())
+    lfs_oids = {f["path"]: (f.get("lfs") or {}).get("oid") for f in tree}
+
+    root = os.path.join(storage, "semantic/models", "models--%s" % HUB_REPO)
+    blobs = os.path.join(root, "blobs")
+    os.makedirs(blobs, exist_ok=True)
+    for name in FILES:
+        oid = lfs_oids.get(name)
+        if oid:
+            blob = oid
+            blob_path = os.path.join(blobs, blob)
+            if not os.path.exists(blob_path):
+                data = fetch("%s/%s/resolve/%s/%s" % (HF, REPO, rev, name))
+                if hashlib.sha256(data).hexdigest() != oid:
+                    raise RuntimeError("LFS checksum mismatch for %s" % name)
+                with open(blob_path, "wb") as fh:
+                    fh.write(data)
+        else:
+            data = fetch("%s/%s/resolve/%s/%s" % (HF, REPO, rev, name))
+            blob = git_blob_sha(data)
+            with open(os.path.join(blobs, blob), "wb") as fh:
+                fh.write(data)
+        snap = os.path.join(root, "snapshots", rev)
+        os.makedirs(snap, exist_ok=True)
+        link = os.path.join(snap, name)
+        if os.path.islink(link) or os.path.exists(link):
+            os.remove(link)
+        os.symlink(os.path.join("..", "..", "blobs", blob), link)
+    refs = os.path.join(root, "refs")
+    os.makedirs(refs, exist_ok=True)
+    with open(os.path.join(refs, "main"), "w") as fh:
+        fh.write(rev)
+
+    ort_dir = os.path.join(storage, "onnxruntime", ORT_VERSION)
+    lib_path = os.path.join(ort_dir, "libonnxruntime.so.%s" % ORT_VERSION)
+    if not os.path.exists(lib_path):
+        os.makedirs(ort_dir, exist_ok=True)
+        tgz = fetch(
+            "https://github.com/microsoft/onnxruntime/releases/download/v%s/"
+            "onnxruntime-linux-x64-%s.tgz" % (ORT_VERSION, ORT_VERSION)
+        )
+        archive_sha256 = hashlib.sha256(tgz).hexdigest()
+        tf = tarfile.open(fileobj=io.BytesIO(tgz), mode="r:gz")
+        lib_entry = tf.extractfile(
+            "onnxruntime-linux-x64-%s/lib/libonnxruntime.so.%s"
+            % (ORT_VERSION, ORT_VERSION)
+        )
+        prov_entry = tf.extractfile(
+            "onnxruntime-linux-x64-%s/lib/libonnxruntime_providers_shared.so"
+            % ORT_VERSION
+        )
+        if lib_entry is None or prov_entry is None:
+            raise RuntimeError("ONNX Runtime archive is missing expected libraries")
+        lib_data = lib_entry.read()
+        prov_data = prov_entry.read()
+        with open(lib_path, "wb") as fh:
+            fh.write(lib_data)
+        os.chmod(lib_path, 0o644)
+        prov_path = os.path.join(ort_dir, "libonnxruntime_providers_shared.so")
+        with open(prov_path, "wb") as fh:
+            fh.write(prov_data)
+        os.chmod(prov_path, 0o644)
+        os.symlink(
+            "libonnxruntime.so.%s" % ORT_VERSION,
+            os.path.join(ort_dir, "libonnxruntime.so.1"),
+        )
+        os.symlink("libonnxruntime.so.1", os.path.join(ort_dir, "libonnxruntime.so"))
+        now = datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%M:%S.") + (
+            "%03dZ" % (datetime.now(timezone.utc).microsecond // 1000)
+        )
+        marker = {
+            "version": ORT_VERSION,
+            "installedAt": now,
+            "sha256": hashlib.sha256(lib_data).hexdigest(),
+            "archiveSha256": archive_sha256,
+        }
+        with open(os.path.join(ort_dir, ".aft-onnx-installed"), "w") as fh:
+            json.dump(marker, fh)
+
+
+if __name__ == "__main__":
+    main()

--- a/src/settings/.config/opencode/plugins/opencode-pca.ts
+++ b/src/settings/.config/opencode/plugins/opencode-pca.ts
@@ -1,0 +1,163 @@
+import type { Plugin, PluginModule } from "@opencode-ai/plugin";
+import type { Message, Part } from "@opencode-ai/sdk";
+
+export interface PreventConsecutiveAssistantOptions {
+  /**
+   * Set to false to bypass the plugin entirely. Defaults to true.
+   */
+  enabled?: boolean;
+
+  /**
+   * Strategy to prevent bad requests on strict providers:
+   * - "merge"   : (Default) Combines consecutive assistant turns (including tool/block arrays) into 1 turn, separated by a space. 0 context loss.
+   * - "inject"  : Inserts synthetic user messages between consecutive assistant messages and at the tail.
+   */
+  strategy?: "merge" | "inject";
+
+  /**
+   * Model ID patterns to target (e.g. ["copilot/*", "claude-3-5*"]).
+   * Uses glob-style matching (*). If empty or omitted, applies to all models.
+   */
+  models?: string[];
+
+  /**
+   * Text used when strategy is set to "inject". Defaults to "Continue."
+   */
+  syntheticMessage?: string;
+}
+
+type MessageWithParts = {
+  info: Message;
+  parts: Part[];
+};
+
+const DEFAULT_SYNTHETIC_MESSAGE = "Continue.";
+
+function matchesModel(currentModel: string, patterns: string[]) {
+  return patterns.some((pattern) => {
+    const escaped = pattern
+      .replace(/[.+^${}()|[\]\\]/g, "\\$&")
+      .replace(/\*/g, ".*");
+    const regexp = new RegExp(`^${escaped}$`);
+    return regexp.test(currentModel);
+  });
+}
+
+function modelOf(messages: MessageWithParts[]): string | undefined {
+  for (const msg of messages) {
+    const info = msg.info;
+    if (info.role === "user" && info.model) {
+      return `${info.model.providerID}/${info.model.modelID}`;
+    }
+    if (info.role === "assistant") {
+      return `${info.providerID}/${info.modelID}`;
+    }
+  }
+  return undefined;
+}
+
+function mergeAssistantParts(prevParts: Part[], nextParts: Part[]): Part[] {
+  const merged = [...prevParts];
+  const lastTextIndex = merged.reduce(
+    (idx, part, i) => (part.type === "text" ? i : idx),
+    -1,
+  );
+  const firstTextIndex = nextParts.findIndex((part) => part.type === "text");
+  if (lastTextIndex !== -1 && firstTextIndex !== -1) {
+    const lastTextPart = merged[lastTextIndex];
+    if (lastTextPart.type === "text") {
+      merged[lastTextIndex] = { ...lastTextPart, text: `${lastTextPart.text} ` };
+    }
+  }
+  merged.push(...nextParts);
+  return merged;
+}
+
+function syntheticUserMessage(template: MessageWithParts, text: string): MessageWithParts {
+  const base = template.info;
+  const sessionID = base.sessionID;
+  const now = Date.now();
+  const messageID = crypto.randomUUID();
+  const textPart: Part = {
+    id: crypto.randomUUID(),
+    sessionID,
+    messageID,
+    type: "text",
+    text,
+    synthetic: true,
+  };
+  return {
+    info: {
+      id: messageID,
+      sessionID,
+      role: "user",
+      time: { created: now },
+      agent: base.role === "user" ? base.agent : "",
+      model:
+        base.role === "user"
+          ? base.model
+          : { providerID: base.providerID, modelID: base.modelID },
+    },
+    parts: [textPart],
+  };
+}
+
+const OpencodePca: Plugin = async (_ctx, options) => {
+  const opts = (options ?? {}) as PreventConsecutiveAssistantOptions;
+  const enabled = opts.enabled ?? true;
+  const strategy = opts.strategy ?? "merge";
+  const allowedModels = opts.models ?? [];
+  const syntheticText = opts.syntheticMessage ?? DEFAULT_SYNTHETIC_MESSAGE;
+
+  return {
+    "experimental.chat.messages.transform": async (_input, output) => {
+      if (!enabled) return;
+
+      if (allowedModels.length > 0) {
+        const model = modelOf(output.messages);
+        if (!model || !matchesModel(model, allowedModels)) return;
+      }
+
+      const messages = [...output.messages];
+      if (messages.length === 0) return;
+
+      if (strategy === "merge") {
+        const merged: MessageWithParts[] = [];
+        for (const msg of messages) {
+          const prev = merged[merged.length - 1];
+          if (prev && prev.info.role === "assistant" && msg.info.role === "assistant") {
+            prev.parts = mergeAssistantParts(prev.parts, msg.parts);
+          } else {
+            merged.push({ info: msg.info, parts: [...msg.parts] });
+          }
+        }
+        output.messages.splice(0, output.messages.length, ...merged);
+
+        const last = output.messages[output.messages.length - 1];
+        if (last && last.info.role === "assistant" && syntheticText) {
+          output.messages.push(syntheticUserMessage(last, syntheticText));
+        }
+      } else if (strategy === "inject") {
+        const sanitized: MessageWithParts[] = [];
+        for (let i = 0; i < messages.length; i++) {
+          const current = messages[i];
+          const next = messages[i + 1];
+          sanitized.push(current);
+          if (current.info.role === "assistant" && next?.info.role === "assistant") {
+            sanitized.push(syntheticUserMessage(current, syntheticText));
+          }
+        }
+        const last = sanitized[sanitized.length - 1];
+        if (last && last.info.role === "assistant" && syntheticText) {
+          sanitized.push(syntheticUserMessage(last, syntheticText));
+        }
+        output.messages.splice(0, output.messages.length, ...sanitized);
+      }
+    },
+  };
+};
+
+export default {
+  id: "opencode-pca",
+  server: OpencodePca,
+} satisfies PluginModule;

--- a/src/settings/.config/opencode/plugins/opencode-pca.ts
+++ b/src/settings/.config/opencode/plugins/opencode-pca.ts
@@ -56,7 +56,11 @@ function modelOf(messages: MessageWithParts[]): string | undefined {
   return undefined;
 }
 
-function mergeAssistantParts(prevParts: Part[], nextParts: Part[]): Part[] {
+function mergeAssistantParts(
+  messageID: string,
+  prevParts: Part[],
+  nextParts: Part[],
+): Part[] {
   const merged = [...prevParts];
   const lastTextIndex = merged.reduce(
     (idx, part, i) => (part.type === "text" ? i : idx),
@@ -69,7 +73,7 @@ function mergeAssistantParts(prevParts: Part[], nextParts: Part[]): Part[] {
       merged[lastTextIndex] = { ...lastTextPart, text: `${lastTextPart.text} ` };
     }
   }
-  merged.push(...nextParts);
+  merged.push(...nextParts.map((part) => ({ ...part, messageID })));
   return merged;
 }
 
@@ -126,7 +130,7 @@ const OpencodePca: Plugin = async (_ctx, options) => {
         for (const msg of messages) {
           const prev = merged[merged.length - 1];
           if (prev && prev.info.role === "assistant" && msg.info.role === "assistant") {
-            prev.parts = mergeAssistantParts(prev.parts, msg.parts);
+            prev.parts = mergeAssistantParts(prev.info.id, prev.parts, msg.parts);
           } else {
             merged.push({ info: msg.info, parts: [...msg.parts] });
           }

--- a/src/settings/.config/personal-setup/aft.jsonc
+++ b/src/settings/.config/personal-setup/aft.jsonc
@@ -1,0 +1,11 @@
+{
+  "search_index": true,
+  "semantic_search": true,
+  "auto_update": false,
+  "bash": {
+    "rewrite": true,
+    "compress": true,
+    "background": true,
+    "subagent_background": true
+  }
+}

--- a/src/settings/.config/personal-setup/magic-context.jsonc
+++ b/src/settings/.config/personal-setup/magic-context.jsonc
@@ -1,0 +1,6 @@
+{
+  "auto_update": false,
+  "historian": {},
+  "dreamer": {},
+  "sidekick": {}
+}

--- a/src/settings/.local/share/scripts/post-install.sh
+++ b/src/settings/.local/share/scripts/post-install.sh
@@ -20,7 +20,7 @@ function reset_git_repos() {
   done
 }
 
-# --- A. Reset Neovim Plugins ---
+# --- Reset Neovim Plugins ---
 if [[ -d "$INSTALL_DIR/.local/share/nvim/lazy" ]]; then
     echo "[Post-Install] Resetting Neovim plugins..."
     cd "$INSTALL_DIR/.local/share/nvim/lazy" || exit
@@ -29,7 +29,7 @@ if [[ -d "$INSTALL_DIR/.local/share/nvim/lazy" ]]; then
     cd "$INSTALL_DIR" || exit
 fi
 
-# --- B. Reset Tinty Plugins ---
+# --- Reset Tinty Plugins ---
 if [[ -d "$INSTALL_DIR/.local/share/tinted-theming/tinty/repos" ]]; then
     echo "[Post-Install] Resetting Tinty plugins..."
     cd "$INSTALL_DIR/.local/share/tinted-theming/tinty/repos" || exit
@@ -38,7 +38,7 @@ if [[ -d "$INSTALL_DIR/.local/share/tinted-theming/tinty/repos" ]]; then
     cd "$INSTALL_DIR" || exit
 fi
 
-# --- C. Restore Git Identity ---
+# --- Restore Git Identity ---
 GIT_CONFIG_BACKUP="$INSTALL_DIR/.config/git/config~"
 TARGET_GIT_CONFIG="$INSTALL_DIR/.config/git/config"
 
@@ -51,6 +51,64 @@ if [[ -f "$GIT_CONFIG_BACKUP" ]]; then
     fi
     if [[ ! -z "$OLD_EMAIL" ]]; then
         git config --file "$TARGET_GIT_CONFIG" user.email "$OLD_EMAIL"
+    fi
+fi
+
+# --- Configure Magic Context ---
+MC_SOURCE="$INSTALL_DIR/.config/personal-setup/magic-context.jsonc"
+MC_TARGET="$INSTALL_DIR/.config/cortexkit/magic-context.jsonc"
+if [[ -f "$MC_SOURCE" ]]; then
+    echo "[Post-Install] Configuring Magic Context..."
+
+    # Mirror the shell profile's OPENCODE_CONFIG override when present
+    CUSTOM_CONFIG="$INSTALL_DIR/.config/opencode/custom.json"
+    if [[ -f "$CUSTOM_CONFIG" ]]; then
+        export OPENCODE_CONFIG="$CUSTOM_CONFIG"
+    fi
+
+    # Pick the first available model, preferring the target's custom config
+    FIRST_MODEL=""
+    if [[ -n "${OPENCODE_CONFIG:-}" ]]; then
+        FIRST_MODEL=$("$INSTALL_DIR/.local/bin/yq" -r '
+            .provider | to_entries
+            | map(select((.value | has("models")) and ((.value.models | keys | length) > 0)))
+            | map(.key + "/" + (.value.models | keys | .[0]))
+            | .[0] // ""
+        ' "$OPENCODE_CONFIG" 2>/dev/null)
+    fi
+    if [[ -z "$FIRST_MODEL" ]]; then
+        FIRST_MODEL=$(HOME="$INSTALL_DIR" XDG_CONFIG_HOME="$INSTALL_DIR/.config" XDG_DATA_HOME="$INSTALL_DIR/.data" XDG_CACHE_HOME="$INSTALL_DIR/.cache" OPENCODE_CONFIG_DIR="$INSTALL_DIR/.config/opencode" "$INSTALL_DIR/.local/bin/opencode" models --pure 2>/dev/null | grep -v '^opencode/' | head -n1)
+    fi
+    if [[ -z "$FIRST_MODEL" ]]; then
+        FIRST_MODEL=$(HOME="$INSTALL_DIR" XDG_CONFIG_HOME="$INSTALL_DIR/.config" XDG_DATA_HOME="$INSTALL_DIR/.data" XDG_CACHE_HOME="$INSTALL_DIR/.cache" OPENCODE_CONFIG_DIR="$INSTALL_DIR/.config/opencode" "$INSTALL_DIR/.local/bin/opencode" models --pure 2>/dev/null | head -n1)
+    fi
+
+    if [[ -n "$FIRST_MODEL" ]]; then
+        for agent in historian dreamer sidekick; do
+            CURRENT=$("$INSTALL_DIR/.local/bin/yq" -r ".${agent}.model // \"\"" "$MC_SOURCE")
+            if [[ -z "$CURRENT" ]]; then
+                "$INSTALL_DIR/.local/bin/yq" -o=json -i ".${agent}.model = \"${FIRST_MODEL}\"" "$MC_SOURCE"
+            fi
+        done
+    fi
+
+    # Symlink into magic-context's user config path, only if absent
+    if [[ ! -e "$MC_TARGET" && ! -L "$MC_TARGET" ]]; then
+        mkdir -p "$(dirname "$MC_TARGET")"
+        ln -s ../personal-setup/magic-context.jsonc "$MC_TARGET"
+    fi
+fi
+
+# --- Configure AFT ---
+AFT_SOURCE="$INSTALL_DIR/.config/personal-setup/aft.jsonc"
+AFT_TARGET="$INSTALL_DIR/.config/cortexkit/aft.jsonc"
+if [[ -f "$AFT_SOURCE" ]]; then
+    echo "[Post-Install] Configuring AFT..."
+
+    # Symlink into AFT's user config path, only if absent
+    if [[ ! -e "$AFT_TARGET" && ! -L "$AFT_TARGET" ]]; then
+        mkdir -p "$(dirname "$AFT_TARGET")"
+        ln -s ../personal-setup/aft.jsonc "$AFT_TARGET"
     fi
 fi
 


### PR DESCRIPTION
# OpenCode AI Summary

**Purpose:** Replace the opencode-dcp/antigravity plugin stack with magic-context and AFT plugins, configured for fully offline (airgap) operation via pre-downloaded models.

**Summary:** Introduces `@cortexkit/opencode-magic-context@0.36.1` and `@cortexkit/aft-opencode@0.50.1` plugins with airgap support, and drops `opencode-dcp`. The opencode config now loads the pca plugin in the required array-tuple form and disables compaction. Magic-context ships a managed draft config (auto_update off, empty historian/dreamer/sidekick agents auto-filled post-install from `opencode models`) and pre-downloads its local embedding model into the release archive. AFT ships a draft config (search_index, semantic_search, auto_update off, full bash sub-features) and pre-downloads the fastembed model plus ONNX Runtime (version derived from the installed aft-bridge at build time) into the archive. Post-install symlinks both configs into `.config/cortexkit/` only when absent, preserving user configs across updates.

---
*This summary was generated automatically by OpenCode.*


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added indexed and semantic search capabilities.
  - Added safeguards against consecutive assistant messages by merging turns or inserting prompts.
  - Added automatic setup for required search models and runtime components.
  - Added post-install configuration for available models and personal settings.

- **Configuration**
  - Updated OpenCode integrations and removed legacy Google-based model options.
  - Disabled automatic updates, compaction, and pruning where configured.
  - Added configurable search and assistant behavior settings.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->