### PR TITLE
chore: enable ruff bandit rules

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -15,8 +15,31 @@ permissions:
   pull-requests: write
 
 jobs:
+  lint:
+    name: Lint
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v7
+
+      - name: Ruff check
+        uses: astral-sh/ruff-action@v4.1.0
+
+      - name: Set up uv
+        uses: astral-sh/setup-uv@v6
+
+      - name: Sync project dependencies
+        run: uv sync
+
+      - name: Ty check
+        uses: JacobCoffee/ty-action@v0.0.1
+        with:
+          args: 'check .'
+
   build:
     name: Build
+    needs: lint
     runs-on: ubuntu-latest
 
     steps:

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 build/
 tests/logs/
 .python-version
+.venv/

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,3 +8,15 @@ dependencies = [
     "requests>=2.32.5",
     "tenacity>=9.1.2",
 ]
+
+[tool.uv]
+package = false
+
+[tool.ruff.lint]
+# Default pycodestyle/pyflakes plus all Bandit security rules.
+select = ["E4", "E7", "E9", "F", "S"]
+
+[tool.ruff.lint.per-file-ignores]
+# build.py deliberately spawns toolchain subprocesses (git, bun, ...) and
+# extracts package archives from pinned release URLs into controlled temp dirs.
+"src/build.py" = ["S202", "S603", "S607"]

--- a/src/build.py
+++ b/src/build.py
@@ -14,7 +14,7 @@ import threading
 import zipfile
 import glob
 from pathlib import Path
-from typing import Dict, List, Optional, Tuple, Union, Set
+from typing import Dict, List, Optional, Union, Set
 
 # Third-party imports
 import requests
@@ -205,11 +205,16 @@ class PackageBuilder:
         return hash_sha.hexdigest()
 
     def get_file_ext(self, url: str) -> str:
-        if (url_path := url.split('?')[0]).endswith(('.tar.gz', '.tgz')): return 'tar.gz'
-        if url_path.endswith('.tar.xz'): return 'tar.xz'
-        if url_path.endswith('.tar.bz2'): return 'tar.bz2'
-        if url_path.endswith('.zip'): return 'zip'
-        if url_path.endswith('.AppImage'): return 'AppImage'
+        if (url_path := url.split('?')[0]).endswith(('.tar.gz', '.tgz')):
+            return 'tar.gz'
+        if url_path.endswith('.tar.xz'):
+            return 'tar.xz'
+        if url_path.endswith('.tar.bz2'):
+            return 'tar.bz2'
+        if url_path.endswith('.zip'):
+            return 'zip'
+        if url_path.endswith('.AppImage'):
+            return 'AppImage'
         return ''
 
     def _force_copy(self, src, dst):
@@ -447,7 +452,8 @@ class PackageBuilder:
                 universal_newlines=True, check=True, timeout=30
             )
             for line in result.stdout.strip().split('\n'):
-                if not line: continue
+                if not line:
+                    continue
                 _, ref = line.split('\t')
                 tag_name = ref.replace('refs/tags/', '')
                 if tag_name.lstrip('v') == version.lstrip('v'):
@@ -519,8 +525,10 @@ class PackageBuilder:
                     head_resp = requests.head(actual_url, allow_redirects=False, timeout=10)
                     if 'content-type' in head_resp.headers:
                         ct = head_resp.headers['content-type'].lower()
-                        if 'gzip' in ct or 'x-tar' in ct: ext = 'tar.gz'
-                        elif 'zip' in ct: ext = 'zip'
+                        if 'gzip' in ct or 'x-tar' in ct:
+                            ext = 'tar.gz'
+                        elif 'zip' in ct:
+                            ext = 'zip'
                 except requests.RequestException:
                     pass
             filename = f"{name}-{version}.{ext}" if ext else f"{name}-{version}"
@@ -654,7 +662,8 @@ class PackageBuilder:
             raise e
 
     def cache_artifacts(self, pkg: Dict, extracted_dir: Path, name: str, version: str):
-        if 'cache' not in pkg: return
+        if 'cache' not in pkg:
+            return
 
         # Fallback to parent dir if extracted_dir is a file (single-file package)
         base_dir = extracted_dir.parent if extracted_dir.is_file() else extracted_dir
@@ -673,7 +682,8 @@ class PackageBuilder:
                     dest.parent.mkdir(parents=True, exist_ok=True)
 
                     if match_path.is_dir():
-                        if dest.exists(): shutil.rmtree(dest)
+                        if dest.exists():
+                            shutil.rmtree(dest)
                         self._recursive_copy(match_path, dest, symlinks=True, copy_function=self._force_copy)
                     else:
                         self._force_copy(match_path, dest)
@@ -682,10 +692,12 @@ class PackageBuilder:
         self._update_registry_key(f"{name}-{version}", 'artifacts_sha256', sha)
 
     def restore_cache(self, pkg: Dict, extracted_dir: Path, name: str, version: str) -> bool:
-        if 'cache' not in pkg: return False
+        if 'cache' not in pkg:
+            return False
 
         cache_base = self.artifacts_cache_dir / f"{name}-{version}"
-        if not cache_base.exists(): return False
+        if not cache_base.exists():
+            return False
 
         # Fallback to parent dir if extracted_dir is a file
         base_dir = extracted_dir.parent if extracted_dir.is_file() else extracted_dir
@@ -710,7 +722,8 @@ class PackageBuilder:
                     target.parent.mkdir(parents=True, exist_ok=True)
 
                     if source.is_dir():
-                        if target.exists(): shutil.rmtree(target)
+                        if target.exists():
+                            shutil.rmtree(target)
                         self._recursive_copy(source, target, symlinks=True, copy_function=self._force_copy)
                     else:
                         self._force_copy(source, target)
@@ -755,7 +768,8 @@ class PackageBuilder:
             # Chmod logic
             if 'chmod' in file_info:
                 val = file_info['chmod']
-                if isinstance(val, str): val = int(val, 8)
+                if isinstance(val, str):
+                    val = int(val, 8)
 
                 # Security checks
                 if val & 0o002:
@@ -954,7 +968,8 @@ class PackageBuilder:
                         logging.warning(f"Failed to delete {f}: {e}")
 
     def process_package(self, pkg: Dict) -> bool:
-        if self.abort_event.is_set(): return False
+        if self.abort_event.is_set():
+            return False
 
         name = pkg['name']
         version = pkg['version']
@@ -996,7 +1011,8 @@ class PackageBuilder:
             if 'init_cmds' in pkg and workspace_dir and workspace_dir.exists():
                 link_path = self.out_dir / '.cache' / 'personal-setup' / f"{name}-{version}"
                 link_path.parent.mkdir(parents=True, exist_ok=True)
-                if link_path.exists(): link_path.unlink()
+                if link_path.exists():
+                    link_path.unlink()
                 try:
                     os.symlink(workspace_dir, link_path)
                 except FileExistsError:


### PR DESCRIPTION
# OpenCode AI Summary

**Purpose:** Enable Bandit security rules (S) in ruff and make the repo lint-clean.

**Summary:** Adds the repo's first `[tool.ruff.lint]` config enabling Bandit S-rules repo-wide (with a documented per-file ignore for `src/build.py`'s idiomatic subprocess/extractall usage), and fixes the resulting violations: `precache-aft.py` gains documented narrow noqas (S310 fixed-path urls, S324 intentional git-blob sha1) and non-executable 0o644 shared libraries; `src/build.py` gets 16 mechanical E701 one-liner conversions plus an unused-import removal. Stacked on top of #1166.

---
*This summary was generated automatically by OpenCode.*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Quality Improvements**
  * Added automated linting, formatting, type checking, and security checks to the release workflow.
  * Releases are now built only after these checks pass.

* **Maintenance**
  * Improved code formatting and import organization without changing runtime behavior.
  * Updated project configuration to support consistent development tooling.
  * Updated ignore rules to exclude local virtual environments.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->