### PR TITLE
feat(opencode): add opencode-ensemble plugin and worktree permission

### DIFF
--- a/packages/opencode/opencode.jsonc
+++ b/packages/opencode/opencode.jsonc
@@ -13,6 +13,7 @@
   "plugin": [
     "@cortexkit/opencode-magic-context@0.37.0",
     "@cortexkit/aft-opencode@0.50.3",
+    "@hueyexe/opencode-ensemble@0.16.0",
     [
       "./plugins/pca/opencode-pca.ts",
       {
@@ -25,6 +26,11 @@
       {}
     ]
   ],
+  "permission": {
+    "external_directory": {
+      "~/.local/share/opencode/worktree/**": "allow"
+    }
+  },
   "lsp": {
     "slang-server": {
       "command": ["slang-server"],


### PR DESCRIPTION
Implements kata issue j92j: Add @hueyexe/opencode-ensemble@0.16.0 npm plugin to opencode config with required worktree permission config for git worktree isolation.

Changes:
- Added @hueyexe/opencode-ensemble@0.16.0 to plugin array
- Added permission.external_directory for ~/.local/share/opencode/worktree/** (required for ensemble worktrees)
- Verified Node 26 runtime satisfies ensemble's node:sqlite requirement (≥24)
- Plugin installed via opencode's bun-based plugin installation in package.yaml init_cmds

Installation follows https://github.com/hueyexe/opencode-ensemble#install

@coderabbitai review

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for the OpenCode Ensemble plugin.
  * Enabled access to OpenCode worktree data for improved workflow integration.
<!-- end of auto-generated comment: release notes by coderabbit.ai --> [DRAFT]