### PR TITLE
feat(opencode): add @bybrawe/opencode-goal plugin

### DIFF
--- a/packages/opencode/commands/goal.md
+++ b/packages/opencode/commands/goal.md
@@ -1,0 +1,10 @@
+---
+description: Set or manage a persistent evidence-verified goal
+---
+
+<!-- managed-by:@bybrawe/opencode-goal -->
+OpenCode Goals command bridge. The OpenCode Goals plugin should intercept this command before model execution.
+If this text reaches the model, do not perform the requested work. Tell the user the OpenCode Goals plugin did not load, then ask them to reinstall/update with npx -y @bybrawe/opencode-goal@latest and fully restart OpenCode.
+
+Requested /goal arguments:
+$ARGUMENTS

--- a/packages/opencode/opencode.jsonc
+++ b/packages/opencode/opencode.jsonc
@@ -14,6 +14,7 @@
     "@cortexkit/opencode-magic-context@0.38.0",
     "@cortexkit/aft-opencode@0.51.2",
     "@hueyexe/opencode-ensemble@0.16.1",
+    "@bybrawe/opencode-goal@1.3.16",
     [
       "./plugins/pca/opencode-pca.ts",
       {

--- a/packages/opencode/package.yaml
+++ b/packages/opencode/package.yaml
@@ -12,6 +12,8 @@ files:
     dst: .config/opencode/schema.json
   - src: "{pkg_dir}/opencode.jsonc"
     dst: .config/opencode/opencode.jsonc
+  - src: "{pkg_dir}/commands/goal.md"
+    dst: .config/opencode/commands/goal.md
 test:
   type: version-check
 init_cmds:


### PR DESCRIPTION
## Summary

Adds the opencode-goal plugin for persistent, host-verified Goal mode in OpenCode.

### Changes

- **opencode.jsonc**: Added `@bybrawe/opencode-goal@1.3.16` to the plugin array, grouped with other npm plugins before local  entries
- **commands/goal.md**: New managed slash command file for `/goal` discovery — contains the bridge fallback text matching the upstream installer's output
- **package.yaml**: Added `files` entry to copy `goal.md` into `.config/opencode/commands/goal.md` at install time

### Notes

- No init_cmds changes needed — the existing plugin loop already runs `bun add` for every npm string in the plugin array
- Renovate's existing npm plugin custom manager auto-detects `@scope/name@version` strings in `opencode.jsonc`, so version bumps are automatic
- No conflict with magic-context (opencode-goal does not register `messages.transform` or `system.transform` hooks)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added a `/goal` command for interacting with OpenCode Goals.
  - The command now accepts requested arguments and provides guidance when the Goals plugin is unavailable.

- **Chores**
  - Enabled the OpenCode Goals plugin.
  - Included the `/goal` command in packaged installations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->