### PR TITLE
chore: set KATA_HOME to XDG-compliant path

### DIFF
--- a/src/settings/.bash_profile
+++ b/src/settings/.bash_profile
@@ -18,6 +18,9 @@ export XDG_DATA_HOME="${XDG_DATA_HOME:-$HOME/.local/share}"
 export XDG_STATE_HOME="${XDG_STATE_HOME:-$HOME/.local/state}"
 export XDG_CACHE_HOME="${XDG_CACHE_HOME:-$HOME/.cache}"
 
+# Kata
+export KATA_HOME="${XDG_DATA_HOME:-$HOME/.local/share}/kata"
+
 # Set display if it's empty
 if [ -z "$DISPLAY" ]; then
   export DISPLAY=:0

--- a/src/settings/.login
+++ b/src/settings/.login
@@ -23,6 +23,11 @@ if ( ! $?XDG_CACHE_HOME ) then
   setenv XDG_CACHE_HOME "$HOME/.cache"
 endif
 
+# Kata
+if ( ! $?KATA_HOME ) then
+  setenv KATA_HOME "${XDG_DATA_HOME:-$HOME/.local/share}/kata"
+endif
+
 # Set display if it's empty
 if ( ! $?DISPLAY ) then
   setenv DISPLAY ":0"


### PR DESCRIPTION
# OpenCode AI Summary

**Purpose:** Set KATA_HOME environment variable to XDG-compliant path

**Summary:** 
- Added `export KATA_HOME="${XDG_DATA_HOME:-$HOME/.local/share}/kata"` to `.bash_profile`
- Added `setenv KATA_HOME "${XDG_DATA_HOME:-$HOME/.local/share}/kata"` to `.login` (csh/tcsh)
- This moves kata data from `~/.kata` to `~/.local/share/kata` following XDG Base Directory Specification

---
*This summary was generated automatically by OpenCode.*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added `KATA_HOME` environment configuration.
  * Uses the XDG data directory when available, with `$HOME/.local/share/kata` as the default location.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->