### PR TITLE
chore: set KATA_HOME to XDG-compliant path

### DIFF
--- a/src/settings/.bash_profile
+++ b/src/settings/.bash_profile
@@ -18,6 +18,9 @@ export XDG_DATA_HOME="${XDG_DATA_HOME:-$HOME/.local/share}"
 export XDG_STATE_HOME="${XDG_STATE_HOME:-$HOME/.local/state}"
 export XDG_CACHE_HOME="${XDG_CACHE_HOME:-$HOME/.cache}"
 
+# Kata
+export KATA_HOME="${XDG_DATA_HOME:-$HOME/.local/share}/kata"
+
 # Set display if it's empty
 if [ -z "$DISPLAY" ]; then
   export DISPLAY=:0

--- a/src/settings/.login
+++ b/src/settings/.login
@@ -23,6 +23,11 @@ if ( ! $?XDG_CACHE_HOME ) then
   setenv XDG_CACHE_HOME "$HOME/.cache"
 endif
 
+# Kata
+if ( ! $?KATA_HOME ) then
+  setenv KATA_HOME "${XDG_DATA_HOME:-$HOME/.local/share}/kata"
+endif
+
 # Set display if it's empty
 if ( ! $?DISPLAY ) then
   setenv DISPLAY ":0"


### PR DESCRIPTION
# OpenCode AI Summary

**Purpose:** Set KATA_HOME to XDG-compliant path ($XDG_CONFIG_HOME/.local/share/kata) instead of default ~/.kata.

**Summary:** Modified src/settings/.bash_profile and src/settings/.login to export KATA_HOME pointing to the XDG-compliant data directory. This follows XDG Base Directory Specification and avoids polluting the home directory with configuration data.

---
*This summary was generated automatically by OpenCode.*
