### PR TITLE
chore: set KATA_HOME to XDG-compliant path

### DIFF
--- a/src/settings/.bash_profile
+++ b/src/settings/.bash_profile
@@ -18,6 +18,9 @@ export XDG_DATA_HOME="${XDG_DATA_HOME:-$HOME/.local/share}"
 export XDG_STATE_HOME="${XDG_STATE_HOME:-$HOME/.local/state}"
 export XDG_CACHE_HOME="${XDG_CACHE_HOME:-$HOME/.cache}"
 
+# Kata
+export KATA_HOME="${KATA_HOME:-${XDG_DATA_HOME:-$HOME/.local/share}/kata}"
+
 # Set display if it's empty
 if [ -z "$DISPLAY" ]; then
   export DISPLAY=:0

--- a/src/settings/.login
+++ b/src/settings/.login
@@ -23,6 +23,15 @@ if ( ! $?XDG_CACHE_HOME ) then
   setenv XDG_CACHE_HOME "$HOME/.cache"
 endif
 
+# Kata
+if ( ! $?KATA_HOME ) then
+  if ( "$XDG_DATA_HOME" != "" ) then
+    setenv KATA_HOME "$XDG_DATA_HOME/kata"
+  else
+    setenv KATA_HOME "$HOME/.local/share/kata"
+  endif
+endif
+
 # Set display if it's empty
 if ( ! $?DISPLAY ) then
   setenv DISPLAY ":0"


### PR DESCRIPTION
## Summary

Set KATA_HOME to XDG-compliant path (`$XDG_DATA_HOME/kata`) instead of default `~/.kata`.

## Changes

- Modified `src/settings/.bash_profile` and `src/settings/.login`
- bash_profile: preserve existing KATA_HOME with `KATA_HOME:-` default wrapper
- login: use tcsh-compatible `$XDG_DATA_HOME/kata` instead of POSIX `${XDG_DATA_HOME:-...}`

---
*This summary was generated automatically by OpenCode.*


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for configuring the application data directory through the `KATA_HOME` environment variable.
  * Automatically defaults to the XDG data directory’s `kata` subdirectory, with a fallback under the home directory.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->