### PR TITLE
chore(opencode): pin ensemble skills from GitHub

### DIFF
--- a/packages/opencode/scripts/init.sh
+++ b/packages/opencode/scripts/init.sh
@@ -61,3 +61,6 @@ for plugin in $PLUGIN_LIST; do
     cp -rf /tmp/opencode-loop/agents/ "$OPENCODE_CONFIG_DIR/"
   fi
 done
+
+# 3. Pin Ensemble skills
+bash "${SCRIPT_DIR}/pin-ensemble-skills.sh"

--- a/packages/opencode/scripts/pin-ensemble-skills.sh
+++ b/packages/opencode/scripts/pin-ensemble-skills.sh
@@ -1,0 +1,29 @@
+#!/usr/bin/env bash
+## Download and pin OpenCode Ensemble skills from a specific commit
+## for reproducibility in airgap environments.
+
+set -euo pipefail
+
+ENSEMBLE_SKILLS_SHA="5cb44fa16cde546453626eb9d7dcfa6eb0157068"
+SKILLS_DIR="$HOME/.config/opencode/skills/opencode-ensemble"
+STAGING_DIR="$(mktemp -d)"
+trap 'rm -rf "${STAGING_DIR}"' EXIT
+
+curl -fsSL --connect-timeout 10 --max-time 60 --retry 3 \
+  "https://api.github.com/repos/hueyexe/opencode-ensemble/tarball/${ENSEMBLE_SKILLS_SHA}" \
+  -o "${STAGING_DIR}/ensemble.tar.gz"
+tar xzf "${STAGING_DIR}/ensemble.tar.gz" -C "${STAGING_DIR}"
+ENSEMBLE_EXTRACTED="$(find "${STAGING_DIR}" -maxdepth 1 -type d -name "hueyexe-opencode-ensemble-*" | head -1)"
+if [[ -z "${ENSEMBLE_EXTRACTED}" ]]; then
+  echo "[opencode] ERROR: failed to extract ensemble skills tarball"
+  exit 1
+fi
+STAGING_SKILLS="${ENSEMBLE_EXTRACTED}/skills/opencode-ensemble/"
+if [[ ! -d "${STAGING_SKILLS}" ]]; then
+  echo "[opencode] ERROR: skills directory not found in tarball"
+  exit 1
+fi
+rm -rf "${SKILLS_DIR}"
+mkdir -p "$(dirname "${SKILLS_DIR}")"
+cp -r "${STAGING_SKILLS}" "${SKILLS_DIR}"
+echo "[opencode] Ensemble skills pinned at ${ENSEMBLE_SKILLS_SHA}"


### PR DESCRIPTION
## Summary

Download and pin ensemble builtin skills from GitHub at a specific commit hash.

## Changes

- Added `src/settings/.config/opencode/skills/pin-ensemble-skills.sh` script
- Script fetches skills from `hueyexe/opencode-ensemble` repo at pinned commit
- Skills directory structure: `SKILL.md` + `references/` directory

---
*This summary was generated automatically by OpenCode.*


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Initialization now installs the OpenCode Ensemble skills automatically after plugin setup.
  - Skills are retrieved from a fixed, pinned version to provide consistent results.
  - The installation is validated before use to help ensure the expected skills are available.
  - Existing skills are replaced with the verified installation.
  - Temporary installation files are cleaned up automatically when setup completes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->