### PR TITLE
chore(opencode): remove opencode-loop patch for native support

### DIFF
--- a/packages/opencode/scripts/init.sh
+++ b/packages/opencode/scripts/init.sh
@@ -52,12 +52,8 @@ for plugin in $PLUGIN_LIST; do
   fi
   if [[ "${plugin}" == @bybrawe/opencode-loop@* ]]; then
     rm -rf /tmp/opencode-loop
-    env OPENCODE_CONFIG_DIR=/tmp/opencode-loop npx -y "${plugin}"
-    # Remove experimental loop goal commands because we have goal plugin
-    rm -rf /tmp/opencode-loop/commands/loop-goal*
+    env OPENCODE_CONFIG_DIR=/tmp/opencode-loop npx -y "${plugin}" --loop-only --without-loop-goals
     cp -rf /tmp/opencode-loop/commands/ "$OPENCODE_CONFIG_DIR/"
-    # Patch local agent to hidden subagent
-    sed -i 's/mode: primary/mode: subagent\nhidden: true/' /tmp/opencode-loop/agents/opencode-loop-local.md
     cp -rf /tmp/opencode-loop/agents/ "$OPENCODE_CONFIG_DIR/"
   fi
 done


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated plugin initialization to use loop-only mode without loop goals.
  * Preserved automatic copying of generated commands and agents into the OpenCode configuration directory.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->