### PR TITLE
feat(opencode): add AFT tmpfs storage provisioner

### DIFF
--- a/src/settings/.bash_profile
+++ b/src/settings/.bash_profile
@@ -48,6 +48,12 @@ if [ -f "${XDG_CONFIG_HOME}/opencode/custom.json" ]; then
   export OPENCODE_CONFIG="${XDG_CONFIG_HOME}/opencode/custom.json"
 fi
 
+# AFT: keep storage off slow/NFS home dirs (cortexkit/aft#263)
+if [ -z "${AFT_STORAGE_DIR:-}" ] && [ -f "$HOME/.local/share/scripts/aft-storage-init.sh" ]; then
+  _aft_root="$(bash "$HOME/.local/share/scripts/aft-storage-init.sh")" && export AFT_STORAGE_DIR="$_aft_root"
+  unset _aft_root
+fi
+
 # Delta
 export DELTA_FEATURES="+side-by-side"
 

--- a/src/settings/.local/share/scripts/aft-storage-init.sh
+++ b/src/settings/.local/share/scripts/aft-storage-init.sh
@@ -1,0 +1,43 @@
+#!/usr/bin/env bash
+# ==============================================================================
+# Provision AFT storage on fast local storage (cortexkit/aft#263).
+#
+# Relocates AFT's runtime storage universe (SQLite DB, trigram/semantic/callgraph
+# indexes, writer leases) off slow or network-mounted home directories by
+# pointing AFT_STORAGE_DIR at tmpfs. The heavy read-mostly asset subtrees
+# (embedding model, ONNX Runtime) stay in the persistent legacy data dir and are
+# borrowed into the fast root via symlinks.
+#
+# Usage: called from .bash_profile / .login. Prints the resolved root on stdout;
+# exits non-zero silently when no fast location is writable.
+# ==============================================================================
+set -euo pipefail
+
+USER_NAME="${USER:-$(id -un)}"
+FAST_ROOT="aft-storage"
+LEGACY="$HOME/.local/share/cortexkit/aft"
+
+# Pick the fastest writable base: /dev/shm first, /tmp as fallback.
+ROOT=""
+for base in "/dev/shm/$USER_NAME" "/tmp/$USER_NAME"; do
+  if mkdir -p "$base/$FAST_ROOT" 2>/dev/null && [ -w "$base/$FAST_ROOT" ]; then
+    ROOT="$base/$FAST_ROOT"
+    break
+  fi
+done
+if [ -z "$ROOT" ]; then
+  exit 1
+fi
+
+# Idempotent fill-if-absent provisioning.
+if [ ! -e "$ROOT/semantic/models" ]; then
+  mkdir -p "$ROOT/semantic"
+  if [ -d "$LEGACY/semantic/models" ]; then
+    ln -sfn "$LEGACY/semantic/models" "$ROOT/semantic/models"
+  fi
+fi
+if [ ! -e "$ROOT/onnxruntime" ] && [ -d "$LEGACY/onnxruntime" ]; then
+  ln -sfn "$LEGACY/onnxruntime" "$ROOT/onnxruntime"
+fi
+
+printf '%s\n' "$ROOT"

--- a/src/settings/.local/share/scripts/aft-storage-init.sh
+++ b/src/settings/.local/share/scripts/aft-storage-init.sh
@@ -18,12 +18,48 @@ FAST_ROOT="aft-storage"
 LEGACY="$HOME/.local/share/cortexkit/aft"
 
 # Pick the fastest writable base: /dev/shm first, /tmp as fallback.
+# Validate ownership, permissions, and symlink safety to prevent attacks.
 ROOT=""
+CURRENT_UID="$(id -u)"
 for base in "/dev/shm/$USER_NAME" "/tmp/$USER_NAME"; do
-  if mkdir -p "$base/$FAST_ROOT" 2>/dev/null && [ -w "$base/$FAST_ROOT" ]; then
-    ROOT="$base/$FAST_ROOT"
-    break
+  # Try to create base directory with restrictive permissions
+  mkdir -p -m 0700 "$base" 2>/dev/null || true
+
+  # Validate base directory: not a symlink, owned by us, mode 0700, writable
+  if [ -L "$base" ] || [ ! -d "$base" ]; then
+    continue
   fi
+  base_owner="$(stat -c '%u' "$base" 2>/dev/null)" || continue
+  if [ "$base_owner" != "$CURRENT_UID" ]; then
+    continue
+  fi
+  # Ensure restrictive permissions (tighten if needed)
+  chmod 0700 "$base" 2>/dev/null || continue
+  if [ ! -w "$base" ]; then
+    continue
+  fi
+
+  # Now validate the final storage directory
+  storage_path="$base/$FAST_ROOT"
+  mkdir -p -m 0700 "$storage_path" 2>/dev/null || true
+
+  # Validate storage directory: not a symlink, owned by us, mode 0700, writable
+  if [ -L "$storage_path" ] || [ ! -d "$storage_path" ]; then
+    continue
+  fi
+  storage_owner="$(stat -c '%u' "$storage_path" 2>/dev/null)" || continue
+  if [ "$storage_owner" != "$CURRENT_UID" ]; then
+    continue
+  fi
+  # Ensure restrictive permissions (tighten if needed)
+  chmod 0700 "$storage_path" 2>/dev/null || continue
+  if [ ! -w "$storage_path" ]; then
+    continue
+  fi
+
+  # All checks passed
+  ROOT="$storage_path"
+  break
 done
 if [ -z "$ROOT" ]; then
   exit 1

--- a/src/settings/.login
+++ b/src/settings/.login
@@ -60,7 +60,7 @@ if ( -f "${XDG_CONFIG_HOME}/opencode/custom.json" ) then
 endif
 
 # AFT: keep storage off slow/NFS home dirs (cortexkit/aft#263)
-if ( ! $?AFT_STORAGE_DIR ) then
+if ( ! $?AFT_STORAGE_DIR || "$AFT_STORAGE_DIR" == "" ) then
   if ( -f "$HOME/.local/share/scripts/aft-storage-init.sh" ) then
     set _aft_root = "`bash $HOME/.local/share/scripts/aft-storage-init.sh`"
     if ( "$_aft_root" != "" ) then

--- a/src/settings/.login
+++ b/src/settings/.login
@@ -60,7 +60,15 @@ if ( -f "${XDG_CONFIG_HOME}/opencode/custom.json" ) then
 endif
 
 # AFT: keep storage off slow/NFS home dirs (cortexkit/aft#263)
-if ( ! $?AFT_STORAGE_DIR || "$AFT_STORAGE_DIR" == "" ) then
+if ( ! $?AFT_STORAGE_DIR ) then
+  if ( -f "$HOME/.local/share/scripts/aft-storage-init.sh" ) then
+    set _aft_root = "`bash $HOME:q/.local/share/scripts/aft-storage-init.sh`"
+    if ( "$_aft_root" != "" ) then
+      setenv AFT_STORAGE_DIR "$_aft_root"
+    endif
+    unset _aft_root
+  endif
+else if ( "$AFT_STORAGE_DIR" == "" ) then
   if ( -f "$HOME/.local/share/scripts/aft-storage-init.sh" ) then
     set _aft_root = "`bash $HOME:q/.local/share/scripts/aft-storage-init.sh`"
     if ( "$_aft_root" != "" ) then

--- a/src/settings/.login
+++ b/src/settings/.login
@@ -62,7 +62,7 @@ endif
 # AFT: keep storage off slow/NFS home dirs (cortexkit/aft#263)
 if ( ! $?AFT_STORAGE_DIR || "$AFT_STORAGE_DIR" == "" ) then
   if ( -f "$HOME/.local/share/scripts/aft-storage-init.sh" ) then
-    set _aft_root = "`bash $HOME/.local/share/scripts/aft-storage-init.sh`"
+    set _aft_root = "`bash $HOME:q/.local/share/scripts/aft-storage-init.sh`"
     if ( "$_aft_root" != "" ) then
       setenv AFT_STORAGE_DIR "$_aft_root"
     endif

--- a/src/settings/.login
+++ b/src/settings/.login
@@ -59,6 +59,17 @@ if ( -f "${XDG_CONFIG_HOME}/opencode/custom.json" ) then
   setenv OPENCODE_CONFIG "${XDG_CONFIG_HOME}/opencode/custom.json"
 endif
 
+# AFT: keep storage off slow/NFS home dirs (cortexkit/aft#263)
+if ( ! $?AFT_STORAGE_DIR ) then
+  if ( -f "$HOME/.local/share/scripts/aft-storage-init.sh" ) then
+    set _aft_root = "`bash $HOME/.local/share/scripts/aft-storage-init.sh`"
+    if ( "$_aft_root" != "" ) then
+      setenv AFT_STORAGE_DIR "$_aft_root"
+    endif
+    unset _aft_root
+  endif
+endif
+
 # Delta
 setenv DELTA_FEATURES "+side-by-side"
 


### PR DESCRIPTION
# OpenCode AI Summary

**Purpose:** Keep AFT storage off slow/NFS home directories using the AFT_STORAGE_DIR knob added in aft-opencode v0.52.2 (cortexkit/aft#263).

**Summary:** Adds a shared provisioner that selects a fast local root (/dev/shm/$USER/aft-storage, falling back to /tmp/$USER), symlinks the heavy read-mostly model assets from the persistent legacy tree, and wires it into .bash_profile and .login so AFT_STORAGE_DIR is exported on login. The provisioner is idempotent and silently no-ops when no fast location exists.

---
*This summary was generated automatically by OpenCode.*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Automatically configures AFT storage when starting a shell session.
  - Selects a secure, writable temporary location to improve runtime performance.
  - Validates ownership, permissions, symlink safety, and writability before use.
  - Preserves access to existing semantic-model and ONNX Runtime assets.
  - Gracefully falls back without disrupting shell startup when suitable storage is unavailable.
  - Applies the configuration consistently across supported shell environments.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->