### PR TITLE
feat(opencode): prefer custom.jsonc over custom.json

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,7 +91,10 @@ return {
 
 ### OpenCode Customization
 
-To configure OpenCode, create `${XDG_CONFIG_HOME}/opencode/custom.jsonc` (or `custom.json`). The `OPENCODE_CONFIG` environment variable is automatically set to this path if the file exists.
+To configure OpenCode, create `${XDG_CONFIG_HOME}/opencode/custom.jsonc` (or
+`custom.json`). If both files exist, `custom.jsonc` takes precedence. The
+`OPENCODE_CONFIG` environment variable is automatically set to the selected
+configuration file.
 
 ## Development Guide
 

--- a/README.md
+++ b/README.md
@@ -91,7 +91,7 @@ return {
 
 ### OpenCode Customization
 
-To configure OpenCode, create `${XDG_CONFIG_HOME}/opencode/custom.json`. The `OPENCODE_CONFIG` environment variable is automatically set to this path if the file exists.
+To configure OpenCode, create `${XDG_CONFIG_HOME}/opencode/custom.jsonc` (or `custom.json`). The `OPENCODE_CONFIG` environment variable is automatically set to this path if the file exists.
 
 ## Development Guide
 

--- a/src/settings/.bash_profile
+++ b/src/settings/.bash_profile
@@ -43,8 +43,10 @@ export PATH="$BUN_INSTALL/bin:$PATH"
 # Mason (Neovim package manager)
 export PATH="${XDG_DATA_HOME}/nvim/mason/bin:$PATH"
 
-# OpenCode
-if [ -f "${XDG_CONFIG_HOME}/opencode/custom.json" ]; then
+# OpenCode custom config (prefer JSONC, fall back to JSON)
+if [ -f "${XDG_CONFIG_HOME}/opencode/custom.jsonc" ]; then
+  export OPENCODE_CONFIG="${XDG_CONFIG_HOME}/opencode/custom.jsonc"
+elif [ -f "${XDG_CONFIG_HOME}/opencode/custom.json" ]; then
   export OPENCODE_CONFIG="${XDG_CONFIG_HOME}/opencode/custom.json"
 fi
 

--- a/src/settings/.local/share/scripts/post-install.sh
+++ b/src/settings/.local/share/scripts/post-install.sh
@@ -60,10 +60,15 @@ MC_TARGET="$INSTALL_DIR/.config/cortexkit/magic-context.jsonc"
 if [[ -f "$MC_SOURCE" ]]; then
     echo "[Post-Install] Configuring Magic Context..."
 
-    # Mirror the shell profile's OPENCODE_CONFIG override when present
-    CUSTOM_CONFIG="$INSTALL_DIR/.config/opencode/custom.json"
+    # Mirror the shell profile's OPENCODE_CONFIG override when present (prefer JSONC, fall back to JSON)
+    CUSTOM_CONFIG="$INSTALL_DIR/.config/opencode/custom.jsonc"
     if [[ -f "$CUSTOM_CONFIG" ]]; then
         export OPENCODE_CONFIG="$CUSTOM_CONFIG"
+    else
+        CUSTOM_CONFIG="$INSTALL_DIR/.config/opencode/custom.json"
+        if [[ -f "$CUSTOM_CONFIG" ]]; then
+            export OPENCODE_CONFIG="$CUSTOM_CONFIG"
+        fi
     fi
 
     # Pick the first available model, preferring the target's custom config

--- a/src/settings/.login
+++ b/src/settings/.login
@@ -54,8 +54,10 @@ setenv PATH "$BUN_INSTALL/bin:$PATH"
 # Mason (Neovim package manager)
 setenv PATH "${XDG_DATA_HOME}/nvim/mason/bin:$PATH"
 
-# OpenCode
-if ( -f "${XDG_CONFIG_HOME}/opencode/custom.json" ) then
+# OpenCode custom config (prefer JSONC, fall back to JSON)
+if ( -f "${XDG_CONFIG_HOME}/opencode/custom.jsonc" ) then
+  setenv OPENCODE_CONFIG "${XDG_CONFIG_HOME}/opencode/custom.jsonc"
+else if ( -f "${XDG_CONFIG_HOME}/opencode/custom.json" ) then
   setenv OPENCODE_CONFIG "${XDG_CONFIG_HOME}/opencode/custom.json"
 endif
 


### PR DESCRIPTION
# OpenCode AI Summary

**Purpose:** Detect `custom.jsonc` in addition to `custom.json` when setting `OPENCODE_CONFIG`, preferring the JSONC format everywhere.

**Summary:** Updated `.bash_profile` and `.login` to set `OPENCODE_CONFIG` from `custom.jsonc` first and fall back to `custom.json`. Mirrored the same jsonc-first precedence in `post-install.sh` (model auto-fill) and documented it in `README.md`. Existing `custom.json` setups continue to work unchanged.

---
*This summary was generated automatically by OpenCode.*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * OpenCode customization now supports both `custom.jsonc` and `custom.json` configuration files.
  * When both files are available, `custom.jsonc` is selected first, with `custom.json` used as a fallback.
  * The active configuration is automatically applied across setup and login workflows.

* **Documentation**
  * Updated configuration guidance to reflect the supported filenames and selection priority.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->