### PR TITLE
fix(aft): disable lsp auto_install

### DIFF
--- a/src/settings/.config/personal-setup/aft.jsonc
+++ b/src/settings/.config/personal-setup/aft.jsonc
@@ -2,6 +2,9 @@
   "search_index": true,
   "semantic_search": true,
   "auto_update": false,
+  "lsp": {
+    "auto_install": false
+  },
   "bash": {
     "rewrite": true,
     "compress": true,


### PR DESCRIPTION
Stacked on #1256.

Set `lsp.auto_install` to `false` in the shipped `aft.jsonc` so language servers are not auto-installed on plugin startup.

https://github.com/cortexkit/aft/blob/main/docs/config.md

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated configuration to disable automatic language server installation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->