### PR TITLE
fix(magic-context): write model into per-harness opencode block

### DIFF
--- a/src/settings/.local/share/scripts/post-install.sh
+++ b/src/settings/.local/share/scripts/post-install.sh
@@ -89,10 +89,17 @@ if [[ -f "$MC_SOURCE" ]]; then
     fi
 
     if [[ -n "$FIRST_MODEL" ]]; then
+        # New magic-context syntax nests model settings under per-harness blocks
+        # (historian.opencode / dreamer.opencode); sidekick.model stays flat.
+        declare -A MC_MODEL_PATH=(
+            [historian]=".historian.opencode.model"
+            [dreamer]=".dreamer.opencode.model"
+            [sidekick]=".sidekick.model"
+        )
         for agent in historian dreamer sidekick; do
-            CURRENT=$("$INSTALL_DIR/.local/bin/yq" -r ".${agent}.model // \"\"" "$MC_SOURCE")
+            CURRENT=$("$INSTALL_DIR/.local/bin/yq" -r "${MC_MODEL_PATH[$agent]} // \"\"" "$MC_SOURCE")
             if [[ -z "$CURRENT" ]]; then
-                "$INSTALL_DIR/.local/bin/yq" -o=json -i ".${agent}.model = \"${FIRST_MODEL}\"" "$MC_SOURCE"
+                "$INSTALL_DIR/.local/bin/yq" -o=json -i "${MC_MODEL_PATH[$agent]} = \"${FIRST_MODEL}\"" "$MC_SOURCE"
             fi
         done
     fi

--- a/src/settings/.local/share/scripts/post-install.sh
+++ b/src/settings/.local/share/scripts/post-install.sh
@@ -99,7 +99,7 @@ if [[ -f "$MC_SOURCE" ]]; then
         for agent in historian dreamer sidekick; do
             CURRENT=$("$INSTALL_DIR/.local/bin/yq" -r "${MC_MODEL_PATH[$agent]} // \"\"" "$MC_SOURCE")
             if [[ -z "$CURRENT" ]]; then
-                "$INSTALL_DIR/.local/bin/yq" -o=json -i "${MC_MODEL_PATH[$agent]} = \"${FIRST_MODEL}\"" "$MC_SOURCE"
+                FIRST_MODEL="$FIRST_MODEL" "$INSTALL_DIR/.local/bin/yq" -o=json -i "${MC_MODEL_PATH[$agent]} = strenv(FIRST_MODEL)" "$MC_SOURCE"
             fi
         done
     fi


### PR DESCRIPTION
magic-context changed its model-settings syntax: model fields moved into per-harness blocks (`historian.opencode.model`, `dreamer.opencode.model`), while `sidekick.model` stays flat.

This updates the post-install auto-fill so it targets the new paths. Idempotency is preserved (fill only when empty).

https://github.com/cortexkit/magic-context/blob/master/CONFIGURATION.md

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected Magic Context model assignment for historian and dreamer harnesses.
  * Preserved support for the existing sidekick model setting.
  * Improved reliability when saving the selected model configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->