### PR TITLE
feat(opencode-wait): honor queued messages and bound waits

### DIFF
--- a/packages/opencode/package.yaml
+++ b/packages/opencode/package.yaml
@@ -16,7 +16,7 @@ files:
     dst: .config/opencode/tui.jsonc
 test:
   type: cmd
-  cmd: "opencode --version && test -d \"$HOME/.config/opencode/skills/opencode-ensemble\" && test -d \"$HOME/.config/opencode/skills/uv-package-manager\""
+  cmd: "opencode --version && test -d \"$HOME/.config/opencode/skills/opencode-ensemble\" && test -d \"$HOME/.config/opencode/skills/uv-package-manager\" && bun test $ROOT_DIR/tests/opencode/wait.test.ts"
 init_cmds:
   - opencode completion > $HOME/.local/share/bash-completion/completions/opencode.bash
   - |

--- a/src/settings/.config/opencode/plugins/wait/opencode-wait.ts
+++ b/src/settings/.config/opencode/plugins/wait/opencode-wait.ts
@@ -1,166 +1,292 @@
 import type { Plugin, PluginModule } from "@opencode-ai/plugin"
 
-interface WaitRequest {
-  settle: (reason: "event" | "timeout") => void
-  filter: (event: WaitEvent) => boolean
-  timeout?: ReturnType<typeof setTimeout>
-}
+const WAIT_MODES = ["timeout", "user_message", "toast"] as const
+const DEFAULT_SECONDS = 300
+const MAX_SECONDS = 3600
+const MESSAGE_LOOKBACK = 100
+const QUEUE_PEEK_DELAY_MS = 5_000
 
-interface WaitEvent {
-  type: string
-  payload?: unknown
-}
+type WaitMode = (typeof WAIT_MODES)[number]
+type WaitReason = "user_message" | "toast" | "timeout" | "aborted" | "session_deleted" | "disposed"
 
 interface WaitOptions {
   until?: string
   seconds?: number
 }
 
-function matchesFilter(event: { type: string; properties?: unknown }, filter: (e: WaitEvent) => boolean): boolean {
-  if (event.type === "tui.toast.show") {
-    return filter({ type: "toast", payload: event.properties })
-  }
-
-  if (event.type === "message.updated") {
-    const props = event.properties as { info?: { role?: string } } | undefined
-    if (props?.info?.role === "user") {
-      return filter({ type: "user_message", payload: event.properties })
-    }
-  }
-
-  return filter({ type: event.type, payload: event.properties })
+interface WaitRequest {
+  sessionID: string
+  messageID: string
+  until: WaitMode
+  settle: (reason: WaitReason) => void
+  timeout?: ReturnType<typeof setTimeout>
+  queuePeek?: ReturnType<typeof setTimeout>
+  abort?: () => void
 }
 
-function createFilter(until: string): (event: WaitEvent) => boolean {
-  switch (until) {
-    case "toast":
-      return (e) => e.type === "toast"
-    case "user_message":
-      return (e) => e.type === "user_message"
-    case "any":
-      return () => true
-    default:
-      return (e) => e.type === until
-  }
+interface MessageInfo {
+  id?: string
+  role?: string
+  sessionID?: string
+  time?: { created?: number; completed?: number }
 }
 
-// Short retention window for the recent-events buffer. This is only meant to
-// cover the narrow race where an event is processed in the same tick as (or
-// just before) a `wait` call registers, not to replay older history — a
-// larger window risks settling a `wait` instantly against a stale, unrelated
-// past event.
-const EVENT_BUFFER_WINDOW_MS = 100
-const EVENT_BUFFER_MAX_LENGTH = 50
+type SessionMessages = Map<string, MessageInfo>
 
-const OpencodeWait: Plugin = async ({ client, $ }) => {
+function messageInfo(message: unknown): MessageInfo | undefined {
+  if (!message || typeof message !== "object") return
+  const entry = message as { info?: unknown }
+  const info = entry.info ?? message
+  if (!info || typeof info !== "object") return
+  return info as MessageInfo
+}
+
+function isAfter(candidate: MessageInfo, current: MessageInfo): boolean {
+  const candidateCreated = candidate.time?.created
+  const currentCreated = current.time?.created
+  if (candidateCreated !== undefined && currentCreated !== undefined && candidateCreated !== currentCreated) {
+    return candidateCreated > currentCreated
+  }
+  return candidate.id !== undefined && current.id !== undefined && candidate.id > current.id
+}
+
+function compareMessages(left: MessageInfo, right: MessageInfo): number {
+  if (isAfter(left, right)) return 1
+  if (isAfter(right, left)) return -1
+  return 0
+}
+
+function orderedMessages(messages: SessionMessages): MessageInfo[] {
+  return [...messages.values()].sort(compareMessages)
+}
+
+function mergeMessage(messages: SessionMessages, info: MessageInfo): void {
+  if (!info.id) return
+  const previous = messages.get(info.id)
+  messages.set(info.id, {
+    ...previous,
+    ...info,
+    time: { ...previous?.time, ...info.time },
+  })
+}
+
+function hasQueuedUserMessageInHistory(messages: MessageInfo[], sessionID: string): boolean {
+  const completed = messages.findLastIndex(
+    (message) => message.role === "assistant" && message.time?.completed !== undefined,
+  )
+  const pending = messages.findLastIndex(
+    (message, index) =>
+      index > completed && message.role === "assistant" && message.time?.completed === undefined,
+  )
+  if (pending === -1) return false
+  return messages.some(
+    (message, index) => index > pending && message.role === "user" && message.sessionID === sessionID,
+  )
+}
+
+export const OpencodeWait: Plugin = async ({ client }) => {
   const promiseRegistry = new Map<string, WaitRequest>()
-  const recentEvents: Array<{ event: { type: string; properties?: unknown }; timestamp: number; seq: number }> = []
-  let eventSeq = 0
+  const messageCache = new Map<string, SessionMessages>()
 
-  function pruneRecentEvents() {
-    const cutoff = Date.now() - EVENT_BUFFER_WINDOW_MS
-    while (recentEvents.length && recentEvents[0].timestamp < cutoff) recentEvents.shift()
-    while (recentEvents.length > EVENT_BUFFER_MAX_LENGTH) recentEvents.shift()
+  function ensureSessionMessages(sessionID: string, currentMessageID?: string): SessionMessages {
+    let messages = messageCache.get(sessionID)
+    if (!messages) {
+      messages = new Map()
+      messageCache.set(sessionID, messages)
+    }
+    if (currentMessageID && !messages.has(currentMessageID)) {
+      mergeMessage(messages, { id: currentMessageID, role: "assistant", sessionID })
+    }
+    return messages
+  }
+
+  function pruneSessionMessages(sessionID: string): void {
+    const messages = messageCache.get(sessionID)
+    if (!messages || messages.size <= MESSAGE_LOOKBACK) return
+
+    const keep = new Set(
+      orderedMessages(messages)
+        .slice(-MESSAGE_LOOKBACK)
+        .flatMap((message) => (message.id ? [message.id] : [])),
+    )
+    for (const request of promiseRegistry.values()) {
+      if (request.sessionID === sessionID) keep.add(request.messageID)
+    }
+    for (const id of messages.keys()) {
+      if (!keep.has(id)) messages.delete(id)
+    }
   }
 
   function processEvent(event: { type: string; properties?: unknown }) {
-    for (const request of promiseRegistry.values()) {
-      if (matchesFilter(event, request.filter)) {
-        request.settle("event")
-      }
+    const properties = event.properties as
+      | {
+          info?: MessageInfo
+          sessionID?: string
+          messageID?: string
+          id?: string
+        }
+      | undefined
+    const eventSessionID = properties?.sessionID ?? properties?.info?.sessionID
+    const eventInfo = messageInfo(properties?.info)
+
+    if (event.type === "message.updated" && eventSessionID && eventInfo) {
+      const messages = messageCache.get(eventSessionID)
+      if (messages) mergeMessage(messages, { ...eventInfo, sessionID: eventInfo.sessionID ?? eventSessionID })
+      pruneSessionMessages(eventSessionID)
     }
+    if (event.type === "message.removed" && eventSessionID) {
+      const messageID = properties?.messageID ?? properties?.info?.id ?? properties?.id
+      if (messageID) messageCache.get(eventSessionID)?.delete(messageID)
+    }
+
+    for (const request of promiseRegistry.values()) {
+      if (
+        (event.type === "message.updated" || event.type === "message.removed") &&
+        eventSessionID === request.sessionID &&
+        hasQueuedUserMessageInHistory(
+          orderedMessages(ensureSessionMessages(request.sessionID, request.messageID)),
+          request.sessionID,
+        )
+      ) {
+        request.settle("user_message")
+        continue
+      }
+      if (event.type === "tui.toast.show" && request.until === "toast") {
+        request.settle("toast")
+        continue
+      }
+      if (event.type === "session.deleted" && properties?.info?.id === request.sessionID) {
+        request.settle("session_deleted")
+        continue
+      }
+      if (event.type === "server.instance.disposed") request.settle("disposed")
+    }
+  }
+
+  async function hasQueuedUserMessage(sessionID: string, currentMessageID: string): Promise<boolean> {
+    // V1 returns the newest limited page in chronological order, matching the TUI.
+    const response = await client.session.messages({
+      path: { id: sessionID },
+      query: { limit: MESSAGE_LOOKBACK },
+    })
+    const messages = ensureSessionMessages(sessionID, currentMessageID)
+    for (const message of response.data ?? []) {
+      const info = messageInfo(message)
+      if (info) mergeMessage(messages, { ...info, sessionID: info.sessionID ?? sessionID })
+    }
+    pruneSessionMessages(sessionID)
+    return hasQueuedUserMessageInHistory(orderedMessages(messages), sessionID)
   }
 
   return {
     event: async ({ event }) => {
-      const seq = ++eventSeq
-      recentEvents.push({ event, timestamp: Date.now(), seq })
-      pruneRecentEvents()
       processEvent(event)
+    },
+
+    dispose: async () => {
+      for (const request of [...promiseRegistry.values()]) request.settle("disposed")
     },
 
     tool: {
       wait: {
         description:
-          "Wait/pause execution for a specified time or until a system event occurs. " +
-          "Use this INSTEAD OF bash sleep/sleep commands for any waiting needs. " +
-          "Supports timed waits (e.g., 300 seconds), waiting for new user messages, " +
-          "or waiting for TUI toast notifications. Returns immediately when the event " +
-          "occurs or the timeout expires. Always prefer this tool over bash sleep for non-blocking waits.",
+          "Pause until a bounded timeout, a current-session user message, or a TUI toast. " +
+          "Current-session user messages always interrupt the wait, including timeout and toast waits. " +
+          "Use this instead of shell sleep commands when no other useful work is available.",
         args: {
           until: {
             type: "string",
-            description:
-              "Event type to wait for: 'toast' (TUI toast), 'user_message' (new user message), " +
-              "'any' (any event), or a raw OpenCode event type (e.g. 'session.created', 'session.idle')",
-            default: "any",
+            enum: WAIT_MODES,
+            description: "Wait mode: 'timeout', 'user_message', or 'toast'",
+            default: "timeout",
           },
           seconds: {
             type: "number",
-            description:
-              "Maximum time to wait in seconds. If 0 or omitted, waits indefinitely until an event occurs.",
-            default: 0,
+            exclusiveMinimum: 0,
+            maximum: MAX_SECONDS,
+            description: `Maximum wait in seconds. Defaults to ${DEFAULT_SECONDS}; must be greater than 0 and no more than ${MAX_SECONDS}.`,
+            default: DEFAULT_SECONDS,
           },
         },
-        async execute(args: WaitOptions) {
-          const until = args.until ?? "any"
-          const seconds = args.seconds ?? 0
+        async execute(args: WaitOptions, context) {
+          const until = args.until ?? "timeout"
+          const seconds = args.seconds ?? DEFAULT_SECONDS
 
-          if (!Number.isFinite(seconds) || seconds < 0) {
-            return "Error: seconds must be a non-negative finite number"
+          if (!WAIT_MODES.includes(until as WaitMode)) {
+            return `Error: until must be one of: ${WAIT_MODES.join(", ")}`
           }
-
-          // Node's setTimeout takes a 32-bit signed integer delay in milliseconds.
-          // Maximum valid delay is 2147483647 ms = 2147483.647 seconds.
-          const MAX_SECONDS = 2147483.647
+          if (!Number.isFinite(seconds) || seconds <= 0) {
+            return "Error: seconds must be a positive finite number"
+          }
           if (seconds > MAX_SECONDS) {
-            return `Error: seconds must not exceed ${MAX_SECONDS} (maximum setTimeout delay)`
+            return `Error: seconds must not exceed ${MAX_SECONDS}`
           }
-          const filter = createFilter(until)
 
           const id = crypto.randomUUID()
-          // Capture the wait registration sequence before any async operations.
-          // Only buffered events with a strictly greater sequence number will be
-          // eligible for replay, preventing stale events from settling this wait.
-          const registeredSeq = eventSeq
-
           return new Promise<string>((resolve) => {
             let settled = false
             let timeout: ReturnType<typeof setTimeout> | undefined
-
-            const settle = (reason: "event" | "timeout") => {
-              if (settled) return
-              settled = true
-              if (timeout) clearTimeout(timeout)
-              promiseRegistry.delete(id)
-              resolve(
-                reason === "timeout"
-                  ? `Wait completed: timed out after ${seconds} seconds`
-                  : `Wait completed: received ${until} event`,
-              )
+            const request: WaitRequest = {
+              sessionID: context.sessionID,
+              messageID: context.messageID,
+              until: until as WaitMode,
+              settle,
             }
 
-            const waitRequest: WaitRequest = { settle, filter }
+            function settle(reason: WaitReason) {
+              if (settled) return
+              settled = true
+              if (timeout !== undefined) clearTimeout(timeout)
+              if (request.queuePeek !== undefined) clearTimeout(request.queuePeek)
+              if (request.abort) context.abort.removeEventListener("abort", request.abort)
+              promiseRegistry.delete(id)
+              if (![...promiseRegistry.values()].some((entry) => entry.sessionID === request.sessionID)) {
+                messageCache.delete(request.sessionID)
+              }
+              switch (reason) {
+                case "user_message":
+                case "toast":
+                  resolve(`Wait completed: received ${reason} event`)
+                  break
+                case "timeout":
+                  resolve(`Wait completed: timed out after ${seconds} seconds`)
+                  break
+                case "aborted":
+                  resolve("Wait completed: interrupted")
+                  break
+                case "session_deleted":
+                  resolve("Wait completed: session deleted")
+                  break
+                case "disposed":
+                  resolve("Wait completed: plugin disposed")
+                  break
+              }
+            }
 
-            // Close the race where a matching event was processed just
-            // before this wait registered: replay the recent-events buffer
-            // and settle immediately if there's a matching event that arrived
-            // after this wait call started (not stale events from before).
-            pruneRecentEvents()
-            const bufferedMatch = recentEvents.find(
-              (entry) => entry.seq > registeredSeq && matchesFilter(entry.event, filter),
-            )
-            if (bufferedMatch) {
-              settle("event")
+            request.settle = settle
+            request.abort = () => settle("aborted")
+            if (context.abort.aborted) {
+              settle("aborted")
               return
             }
 
-            if (seconds > 0) {
-              timeout = setTimeout(() => settle("timeout"), seconds * 1000)
-              waitRequest.timeout = timeout
-            }
+            context.abort.addEventListener("abort", request.abort, { once: true })
+            promiseRegistry.set(id, request)
+            ensureSessionMessages(context.sessionID, context.messageID)
 
-            promiseRegistry.set(id, waitRequest)
+            // Let the event hook handle new messages immediately. A one-shot,
+            // delayed history peek catches input queued before registration without
+            // adding a request for waits that finish quickly.
+            request.queuePeek = setTimeout(() => {
+              void hasQueuedUserMessage(context.sessionID, context.messageID)
+                .then((queued) => {
+                  if (queued) settle("user_message")
+                })
+                .catch(() => undefined)
+            }, QUEUE_PEEK_DELAY_MS)
+
+            timeout = setTimeout(() => settle("timeout"), seconds * 1000)
+            request.timeout = timeout
           })
         },
       },

--- a/tests/opencode/wait.test.ts
+++ b/tests/opencode/wait.test.ts
@@ -1,0 +1,376 @@
+import { expect, test } from "bun:test"
+import type { Hooks, PluginInput, ToolContext } from "@opencode-ai/plugin"
+
+const CURRENT_MESSAGE_ID = "msg_0002"
+
+type WaitMode = "timeout" | "user_message" | "toast"
+
+interface MessageFixture {
+  info: {
+    id: string
+    role: "user" | "assistant"
+    sessionID: string
+    time: { created: number; completed?: number }
+  }
+}
+
+interface MessagesRequest {
+  path: { id: string }
+  query?: { limit?: number }
+}
+
+interface SetupOptions {
+  messages?: MessageFixture[]
+  messagesResponse?: Promise<{ data: MessageFixture[] }>
+  onMessagesQuery?: (request: MessagesRequest) => void
+}
+
+interface TestContext {
+  tool: ToolContext
+  controller: AbortController
+}
+
+interface WaitDefinition {
+  args: { until: { enum: readonly WaitMode[] } }
+  execute(args: { until?: string; seconds?: number }, context: ToolContext): Promise<string>
+}
+
+interface TestEvent {
+  type: string
+  properties?: unknown
+}
+
+type SessionClient = PluginInput["client"]["session"]
+type PluginEvent = Parameters<NonNullable<Hooks["event"]>>[0]["event"]
+
+function history(queued = false): MessageFixture[] {
+  const olderUser: MessageFixture = {
+    info: { id: "msg_0001", role: "user", sessionID: "s1", time: { created: 1 } },
+  }
+  const currentAssistant: MessageFixture = {
+    info: { id: CURRENT_MESSAGE_ID, role: "assistant", sessionID: "s1", time: { created: 2 } },
+  }
+  const queuedUser: MessageFixture = {
+    info: { id: "msg_0003", role: "user", sessionID: "s1", time: { created: 3 } },
+  }
+  return queued ? [olderUser, currentAssistant, queuedUser] : [olderUser, currentAssistant]
+}
+
+async function setup(options: SetupOptions = {}): Promise<Hooks> {
+  const messages = options.messages ?? history()
+  const messagesResponse = options.messagesResponse ?? Promise.resolve({ data: messages })
+  const client = {
+    session: {
+      messages: (async (request: MessagesRequest) => {
+        options.onMessagesQuery?.(request)
+        return messagesResponse
+      }) as unknown as SessionClient["messages"],
+    },
+  }
+  const waitModule = await import("../../src/settings/.config/opencode/plugins/wait/opencode-wait.ts")
+  return waitModule.OpencodeWait({ client: client as unknown as PluginInput["client"] } as PluginInput)
+}
+
+function context(sessionID = "s1", messageID = CURRENT_MESSAGE_ID): TestContext {
+  const controller = new AbortController()
+  const tool: ToolContext = {
+    sessionID,
+    messageID,
+    agent: "build",
+    directory: process.cwd(),
+    worktree: process.cwd(),
+    abort: controller.signal,
+    metadata() {},
+    async ask() {},
+  }
+  return { tool, controller }
+}
+
+function waitDefinition(hooks: Hooks): WaitDefinition {
+  return hooks.tool!.wait as unknown as WaitDefinition
+}
+
+async function emit(hooks: Hooks, event: TestEvent): Promise<void> {
+  await hooks.event!({ event: event as PluginEvent })
+}
+
+async function remainsPending(promise: Promise<unknown>): Promise<boolean> {
+  let settled = false
+  void promise.finally(() => {
+    settled = true
+  })
+  for (let index = 0; index < 4; index += 1) await Promise.resolve()
+  return !settled
+}
+
+async function captureTimeout(action: () => Promise<string>): Promise<{ result: string; delay: number }> {
+  const originalSetTimeout = globalThis.setTimeout
+  let delay = -1
+  globalThis.setTimeout = ((callback: Parameters<typeof setTimeout>[0], milliseconds?: number, ...args: unknown[]) => {
+    delay = milliseconds ?? 0
+    queueMicrotask(() => (callback as (...values: unknown[]) => void)(...args))
+    return 0 as unknown as ReturnType<typeof setTimeout>
+  }) as typeof setTimeout
+  try {
+    return { result: await action(), delay }
+  } finally {
+    globalThis.setTimeout = originalSetTimeout
+  }
+}
+
+async function runQueuePeek(action: () => Promise<string>): Promise<{ result: string; delay: number }> {
+  const originalSetTimeout = globalThis.setTimeout
+  const originalClearTimeout = globalThis.clearTimeout
+  const timers: Array<{ callback: () => void; delay: number }> = []
+  globalThis.setTimeout = ((callback: Parameters<typeof setTimeout>[0], milliseconds?: number, ...args: unknown[]) => {
+    timers.push({
+      callback: () => (callback as (...values: unknown[]) => void)(...args),
+      delay: milliseconds ?? 0,
+    })
+    return timers.length as unknown as ReturnType<typeof setTimeout>
+  }) as typeof setTimeout
+  globalThis.clearTimeout = (() => undefined) as typeof clearTimeout
+  try {
+    const promise = action()
+    for (let index = 0; index < 4; index += 1) await Promise.resolve()
+    const queuePeek = timers.find((timer) => timer.delay === 5_000)
+    if (!queuePeek) throw new Error("queue peek timer was not scheduled")
+    queuePeek.callback()
+    return { result: await promise, delay: queuePeek.delay }
+  } finally {
+    globalThis.setTimeout = originalSetTimeout
+    globalThis.clearTimeout = originalClearTimeout
+  }
+}
+
+test("publishes only the supported wait modes", async () => {
+  const wait = waitDefinition(await setup())
+  expect(wait.args.until.enum).toEqual(["timeout", "user_message", "toast"])
+})
+
+test("rejects unsupported wait modes", async () => {
+  const wait = waitDefinition(await setup())
+  expect(await wait.execute({ until: "any", seconds: 1 }, context().tool)).toContain("until")
+  expect(await wait.execute({ until: "session.idle", seconds: 1 }, context().tool)).toContain("until")
+})
+
+test("rejects invalid timeout values", async () => {
+  const wait = waitDefinition(await setup())
+  for (const seconds of [0, -1, Number.NaN, Number.POSITIVE_INFINITY, Number.NEGATIVE_INFINITY]) {
+    expect(await wait.execute({ until: "timeout", seconds }, context().tool)).toContain("positive")
+  }
+  expect(await wait.execute({ until: "timeout", seconds: 3600.001 }, context().tool)).toContain("3600")
+})
+
+test("uses the default duration when arguments are omitted", async () => {
+  const wait = waitDefinition(await setup())
+  const captured = await captureTimeout(() => wait.execute({}, context().tool))
+  expect(captured).toEqual({ result: "Wait completed: timed out after 300 seconds", delay: 300_000 })
+})
+
+test("accepts positive and maximum timeout values", async () => {
+  const wait = waitDefinition(await setup())
+  const positive = await captureTimeout(() => wait.execute({ until: "timeout", seconds: 1.25 }, context().tool))
+  expect(positive).toEqual({ result: "Wait completed: timed out after 1.25 seconds", delay: 1_250 })
+
+  const maximum = await captureTimeout(() => wait.execute({ until: "timeout", seconds: 3600 }, context().tool))
+  expect(maximum).toEqual({ result: "Wait completed: timed out after 3600 seconds", delay: 3_600_000 })
+})
+
+test("detects queued users in the V1 history page", async () => {
+  const requests: MessagesRequest[] = []
+  const wait = waitDefinition(
+    await setup({ messages: history(true), onMessagesQuery: (request) => requests.push(request) }),
+  )
+  const result = await runQueuePeek(() => wait.execute({ until: "timeout", seconds: 6 }, context().tool))
+  expect(result).toEqual({ result: "Wait completed: received user_message event", delay: 5_000 })
+  expect(requests[0]).toEqual({ path: { id: "s1" }, query: { limit: 100 } })
+})
+
+test("uses the bounded ID fallback without fetching the current message", async () => {
+  const requests: MessagesRequest[] = []
+  const messages: MessageFixture[] = [
+    { info: { id: "msg_0001", role: "user", sessionID: "s1", time: { created: 1 } } },
+    { info: { id: "msg_0003", role: "user", sessionID: "s1", time: { created: 3 } } },
+  ]
+  const wait = waitDefinition(await setup({ messages, onMessagesQuery: (request) => requests.push(request) }))
+  const result = await runQueuePeek(() => wait.execute({ until: "timeout", seconds: 6 }, context().tool))
+  expect(result.result).toBe("Wait completed: received user_message event")
+  expect(requests).toHaveLength(1)
+})
+
+test("matches the TUI pending boundary with concurrent assistants", async () => {
+  const messages: MessageFixture[] = [
+    { info: { id: "msg_0001", role: "user", sessionID: "s1", time: { created: 1 } } },
+    { info: { id: CURRENT_MESSAGE_ID, role: "assistant", sessionID: "s1", time: { created: 2 } } },
+    { info: { id: "msg_0003", role: "user", sessionID: "s1", time: { created: 3 } } },
+    { info: { id: "msg_0004", role: "assistant", sessionID: "s1", time: { created: 4 } } },
+    { info: { id: "msg_0005", role: "user", sessionID: "s1", time: { created: 5 } } },
+  ]
+  const wait = waitDefinition(await setup({ messages }))
+  const result = await runQueuePeek(() => wait.execute({ until: "timeout", seconds: 6 }, context().tool))
+  expect(result.result).toBe("Wait completed: received user_message event")
+})
+
+test("does not queue a user before the latest incomplete assistant", async () => {
+  const messages: MessageFixture[] = [
+    { info: { id: "msg_0001", role: "user", sessionID: "s1", time: { created: 1 } } },
+    { info: { id: CURRENT_MESSAGE_ID, role: "assistant", sessionID: "s1", time: { created: 2 } } },
+    { info: { id: "msg_0003", role: "user", sessionID: "s1", time: { created: 3 } } },
+    { info: { id: "msg_0004", role: "assistant", sessionID: "s1", time: { created: 4 } } },
+  ]
+  const wait = waitDefinition(await setup({ messages }))
+  const result = await captureTimeout(() => wait.execute({ until: "timeout", seconds: 2 }, context().tool))
+  expect(result.result).toBe("Wait completed: timed out after 2 seconds")
+})
+
+test("does not treat older user messages as queued", async () => {
+  const hooks = await setup({ messages: history(false) })
+  const ctx = context()
+  const pending = waitDefinition(hooks).execute({ until: "timeout", seconds: 2 }, ctx.tool)
+  expect(await remainsPending(pending)).toBe(true)
+  ctx.controller.abort()
+  expect(await pending).toBe("Wait completed: interrupted")
+})
+
+test("new current-session users interrupt every wait mode", async () => {
+  for (const until of ["timeout", "user_message", "toast"] as const) {
+    const hooks = await setup()
+    const pending = waitDefinition(hooks).execute({ until, seconds: 2 }, context().tool)
+    await emit(hooks, {
+      type: "message.updated",
+      properties: { info: { id: "msg_0003", role: "user", sessionID: "s1" } },
+    })
+    expect(await pending).toBe("Wait completed: received user_message event")
+  }
+})
+
+test("accepts the session ID from the event properties", async () => {
+  const hooks = await setup()
+  const pending = waitDefinition(hooks).execute({ until: "user_message", seconds: 2 }, context().tool)
+  await emit(hooks, {
+    type: "message.updated",
+    properties: { sessionID: "s1", info: { id: "msg_0003", role: "user" } },
+  })
+  expect(await pending).toBe("Wait completed: received user_message event")
+})
+
+test("updates the pending boundary when an assistant is removed", async () => {
+  const hooks = await setup()
+  const pending = waitDefinition(hooks).execute({ until: "user_message", seconds: 2 }, context().tool)
+  await emit(hooks, {
+    type: "message.updated",
+    properties: { sessionID: "s1", info: { id: "msg_0004", role: "assistant" } },
+  })
+  await emit(hooks, {
+    type: "message.updated",
+    properties: { sessionID: "s1", info: { id: "msg_0003", role: "user" } },
+  })
+  expect(await remainsPending(pending)).toBe(true)
+  await emit(hooks, {
+    type: "message.removed",
+    properties: { sessionID: "s1", messageID: "msg_0004" },
+  })
+  expect(await pending).toBe("Wait completed: received user_message event")
+})
+
+test("uses the latest incomplete assistant for concurrent waits", async () => {
+  const hooks = await setup()
+  const first = waitDefinition(hooks).execute({ until: "user_message", seconds: 2 }, context("s1", "msg_0002").tool)
+  const second = waitDefinition(hooks).execute({ until: "user_message", seconds: 2 }, context("s1", "msg_0004").tool)
+  await emit(hooks, {
+    type: "message.updated",
+    properties: { sessionID: "s1", info: { id: "msg_0003", role: "user" } },
+  })
+  expect(await remainsPending(first)).toBe(true)
+  expect(await remainsPending(second)).toBe(true)
+  await emit(hooks, {
+    type: "message.updated",
+    properties: { sessionID: "s1", info: { id: "msg_0005", role: "user" } },
+  })
+  expect(await first).toBe("Wait completed: received user_message event")
+  expect(await second).toBe("Wait completed: received user_message event")
+})
+
+test("ignores stale and other-session user events", async () => {
+  const hooks = await setup()
+  const ctx = context()
+  const pending = waitDefinition(hooks).execute({ until: "user_message", seconds: 2 }, ctx.tool)
+  await emit(hooks, {
+    type: "message.updated",
+    properties: { info: { id: "msg_0003", role: "user", sessionID: "other" } },
+  })
+  await emit(hooks, {
+    type: "message.updated",
+    properties: { info: { id: "msg_0001", role: "user", sessionID: "s1" } },
+  })
+  await emit(hooks, {
+    type: "message.updated",
+    properties: { info: { role: "user", sessionID: "s1" } },
+  })
+  expect(await remainsPending(pending)).toBe(true)
+  ctx.controller.abort()
+  expect(await pending).toBe("Wait completed: interrupted")
+})
+
+test("registers before the queued-history request completes", async () => {
+  let resolveHistory: (value: { data: MessageFixture[] }) => void = () => undefined
+  const messagesResponse = new Promise<{ data: MessageFixture[] }>((resolve) => {
+    resolveHistory = resolve
+  })
+  const hooks = await setup({ messagesResponse })
+  const pending = waitDefinition(hooks).execute({ until: "user_message", seconds: 2 }, context().tool)
+  await emit(hooks, {
+    type: "message.updated",
+    properties: { info: { id: "msg_0003", role: "user", sessionID: "s1" } },
+  })
+  expect(await pending).toBe("Wait completed: received user_message event")
+  resolveHistory({ data: history(false) })
+})
+
+test("toasts wake only toast waits", async () => {
+  const hooks = await setup()
+  const toast = waitDefinition(hooks).execute({ until: "toast", seconds: 2 }, context().tool)
+  const timerContext = context()
+  const timer = waitDefinition(hooks).execute({ until: "timeout", seconds: 2 }, timerContext.tool)
+  await emit(hooks, { type: "tui.toast.show", properties: { message: "ok" } })
+  expect(await toast).toBe("Wait completed: received toast event")
+  expect(await remainsPending(timer)).toBe(true)
+  timerContext.controller.abort()
+  expect(await timer).toBe("Wait completed: interrupted")
+})
+
+test("pre-aborted and active requests settle on interruption", async () => {
+  const hooks = await setup()
+  const preAborted = context()
+  preAborted.controller.abort()
+  expect(await waitDefinition(hooks).execute({ until: "timeout", seconds: 2 }, preAborted.tool)).toBe(
+    "Wait completed: interrupted",
+  )
+
+  const active = context()
+  const pending = waitDefinition(hooks).execute({ until: "timeout", seconds: 2 }, active.tool)
+  active.controller.abort()
+  expect(await pending).toBe("Wait completed: interrupted")
+})
+
+test("session deletion settles only that session's waits", async () => {
+  const hooks = await setup()
+  const first = waitDefinition(hooks).execute({ until: "timeout", seconds: 2 }, context("s1").tool)
+  const secondContext = context("s2")
+  const second = waitDefinition(hooks).execute({ until: "timeout", seconds: 2 }, secondContext.tool)
+  await emit(hooks, { type: "session.deleted", properties: { info: { id: "s1" } } })
+  expect(await first).toBe("Wait completed: session deleted")
+  expect(await remainsPending(second)).toBe(true)
+  secondContext.controller.abort()
+  expect(await second).toBe("Wait completed: interrupted")
+})
+
+test("disposal settles every pending wait", async () => {
+  const hooks = await setup()
+  const first = waitDefinition(hooks).execute({ until: "timeout", seconds: 2 }, context("s1").tool)
+  const second = waitDefinition(hooks).execute({ until: "toast", seconds: 2 }, context("s2").tool)
+  await hooks.dispose!()
+  expect(await first).toBe("Wait completed: plugin disposed")
+  expect(await second).toBe("Wait completed: plugin disposed")
+})


### PR DESCRIPTION
# OpenCode AI Summary

**Purpose:** Make the OpenCode wait tool reliably detect queued user messages in concurrent V1 sessions while keeping waits bounded and cancellable.

**Summary:** Restricts wait modes and durations, scopes events to the invoking session, handles abort and disposal cleanup, and performs a delayed V1 history check. The history check mirrors the TUI's latest-incomplete-assistant queue boundary, maintains a per-session cache synchronized by message events, and covers concurrent assistant activity. Deterministic regression tests cover timers, event ordering, queue detection, cache updates, session isolation, and invalid inputs. The flaky real-server API probe was removed from the default package gate.

---
*This summary was generated automatically by OpenCode.*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added bounded wait handling for timeouts, user messages, and toast notifications.
  - Wait durations now support positive values up to 3,600 seconds.
  - Detects queued user messages and responds appropriately.

- **Bug Fixes**
  - Improved cancellation and cleanup when sessions or the application are closed.
  - Prevented unsupported wait modes and invalid durations from being accepted.
  - Improved handling of competing events and message timing.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->